### PR TITLE
[WIP] textlint導入

### DIFF
--- a/.github/workflows/lint_markdowns.yml
+++ b/.github/workflows/lint_markdowns.yml
@@ -1,0 +1,23 @@
+name: textlint
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+
+      - name: Npm install
+        run: |
+          npm ci
+      - name: Running lint
+        run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Node.js
+node_modules/

--- a/.textlintrc
+++ b/.textlintrc
@@ -1,0 +1,38 @@
+{
+  "rules": {
+    // 文章中の同義語を表記ゆれをチェックする
+    // https://github.com/textlint-ja/textlint-rule-no-synonyms
+    "@textlint-ja/no-synonyms": true,
+    // 漢字よりもひらがなで表記したほうが読みやすい形式名詞を指摘する
+    // https://github.com/lostandfound/textlint-rule-ja-hiragana-keishikimeishi
+    "ja-hiragana-keishikimeishi": true,
+    // よくある誤用をチェックする
+    // https://github.com/textlint-ja/textlint-rule-ja-no-abusage
+    "ja-no-abusage": true,
+    // 冗長な表現を禁止する
+    // https://github.com/textlint-ja/textlint-rule-ja-no-redundant-expression
+    "ja-no-redundant-expression": true,
+    // 漢字が連続する最大文字数を制限する（最大5文字）
+    // https://github.com/textlint-ja/textlint-rule-max-kanji-continuous-len
+    "max-kanji-continuous-len": {
+      max: 5,
+    },
+    // ら抜き言葉を検出する
+    // https://github.com/textlint-ja/textlint-rule-no-dropping-the-ra
+    "no-dropping-the-ra": true,
+    // 全角と半角アルファベットの混在をチェックする
+    // https://github.com/textlint-ja/textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet
+    "no-mixed-zenkaku-and-hankaku-alphabet": true,
+    // インラインコードの前後にスペースを入れる
+    // https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-code
+    "ja-space-around-code": {
+        "before": true,
+        "after": true,
+    },
+    // ymlファイルをもとに表記をチェックする
+    // https://github.com/textlint-rule/textlint-rule-prh
+    "prh": {
+      "rulePaths": ["prh-rules/wordpress.yml"],
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2387 @@
+{
+  "name": "wordpress-textlint",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@azu/format-text": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.1.tgz",
+      "integrity": "sha512-fyPhr8C1DHQqq/xC8gIg2jmYTw/SoY+KgtVFs6H+DFhfh4Hr4OSDeQZuK1eGpOjhuckWy9A1Hhq84+uRjoznLQ==",
+      "dev": true
+    },
+    "@azu/style-format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.0.tgz",
+      "integrity": "sha512-L7iaxNrk0OLsH7kw3yx3KVQTKhc2zeW0D9SLrRCqbTZi3XtvSVmmjqO73kR4EnWbTRZ18mwdAikbFYJ0coZ55Q==",
+      "dev": true,
+      "requires": {
+        "@azu/format-text": "^1.0.1"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.6.tgz",
+      "integrity": "sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw==",
+      "dev": true
+    },
+    "@textlint-ja/textlint-rule-no-synonyms": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@textlint-ja/textlint-rule-no-synonyms/-/textlint-rule-no-synonyms-1.3.0.tgz",
+      "integrity": "sha512-mOB85gFGnSx6LgoUdCQFyATjcfsi0UaWO8Q4EBna/cq+ZGlmg2vcDGozk1hNLhX8u1PMzZDxDwrQOqx1zW+42w==",
+      "dev": true,
+      "requires": {
+        "textlint-rule-helper": "^2.1.1",
+        "tiny-segmenter": "^0.2.0"
+      }
+    },
+    "@textlint/ast-node-types": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.2.1.tgz",
+      "integrity": "sha512-NXYza6aG1+LdZ4g83gjRhDht+gdrTjJYkdcQhpvzNCtTar/sVpaykkauRcAKLhkIWrQpfb311pfMlU6qNDW76Q==",
+      "dev": true
+    },
+    "@textlint/ast-tester": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-12.2.1.tgz",
+      "integrity": "sha512-QGg7wxFLpsEAb7uxYPAO6F/QxDoX50wQ8aQ378RbpcQK57J9r9TQfV5Sieuta5dJORUrrMIuIrP4qU7P+1YyUw==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^12.2.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "@textlint/ast-traverse": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-12.2.1.tgz",
+      "integrity": "sha512-uwppnDZRmRhH8R4WrkKAvwAbKcYux2yG/XqKlADuFd2T4hSMTlZOBLxDvXohLKY617HHM32/G99HJlmFFvP4GA==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^12.2.1"
+      }
+    },
+    "@textlint/feature-flag": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-12.2.1.tgz",
+      "integrity": "sha512-Vwn1VKaqNvhMteXNdvk+5duGzlG0MwSjkufU3AVaBQsS4SH4dchSvULpKc+r4BOTSzybNappN0APEcMjOx0Lxg==",
+      "dev": true
+    },
+    "@textlint/fixer-formatter": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-12.2.1.tgz",
+      "integrity": "sha512-Y4FT2zVyYCxZCJ19tdfhBKr/FtCDP03iW+gfF6zHAjQaNPEGUU7ZfVUBJVVYBWOuHT/Zk22kcJZVFSINacPybQ==",
+      "dev": true,
+      "requires": {
+        "@textlint/module-interop": "^12.2.1",
+        "@textlint/types": "^12.2.1",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "diff": "^4.0.2",
+        "is-file": "^1.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0",
+        "try-resolve": "^1.0.1"
+      }
+    },
+    "@textlint/kernel": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-12.2.1.tgz",
+      "integrity": "sha512-imKBeglOKVwsVmrCDzIHf8uiYXtEy0VFyPPb7GYiLhA2pImh59QOtuoPiMT0h8ctV5Aa2konOQVV6jM+JJ9xkQ==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^12.2.1",
+        "@textlint/ast-tester": "^12.2.1",
+        "@textlint/ast-traverse": "^12.2.1",
+        "@textlint/feature-flag": "^12.2.1",
+        "@textlint/source-code-fixer": "^12.2.1",
+        "@textlint/types": "^12.2.1",
+        "@textlint/utils": "^12.2.1",
+        "debug": "^4.3.4",
+        "deep-equal": "^1.1.1",
+        "structured-source": "^3.0.2"
+      }
+    },
+    "@textlint/linter-formatter": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-12.2.1.tgz",
+      "integrity": "sha512-xfVRM+DRrJzBswzrYpmNDJDfapYyogOGlwOXb9Omc7/MvipVreG0WvtgSgxchJ+1nPJwsOPES8PAgQYcPR20+Q==",
+      "dev": true,
+      "requires": {
+        "@azu/format-text": "^1.0.1",
+        "@azu/style-format": "^1.0.0",
+        "@textlint/module-interop": "^12.2.1",
+        "@textlint/types": "^12.2.1",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "is-file": "^1.0.0",
+        "js-yaml": "^3.14.1",
+        "optionator": "^0.9.1",
+        "pluralize": "^2.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "table": "^6.8.0",
+        "text-table": "^0.2.0",
+        "try-resolve": "^1.0.1",
+        "xml-escape": "^1.1.0"
+      }
+    },
+    "@textlint/markdown-to-ast": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.2.1.tgz",
+      "integrity": "sha512-p+LlVcrgHnSNEWWflYU412uu+v4Cejs6hmI4SgZCheNg4u7Ik78aKgpe4jT5BhjLSBZ/KP6IrJxtCUOoJIUWmQ==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^12.2.1",
+        "debug": "^4.3.4",
+        "remark-footnotes": "^3.0.0",
+        "remark-frontmatter": "^3.0.0",
+        "remark-gfm": "^1.0.0",
+        "remark-parse": "^9.0.0",
+        "traverse": "^0.6.6",
+        "unified": "^9.2.2"
+      }
+    },
+    "@textlint/module-interop": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-12.2.1.tgz",
+      "integrity": "sha512-/SixwKngWuTvVl9AArK4FEWGrNAwD7/ABvLCy/pdFprljnUa87P5JvSi7/v1PjpAXcnMQ2r04wDJjegs9oblBA==",
+      "dev": true
+    },
+    "@textlint/regexp-string-matcher": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-1.1.1.tgz",
+      "integrity": "sha512-rrNUCKGKYBrZALotSF8D5A8xD05VHX6kxv0BP805Ig2M73Ha6LK+de31+ZocGm4CO+sikVFYyMCPPJhp7bCXcw==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0",
+        "execall": "^2.0.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqwith": "^4.5.0",
+        "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
+      }
+    },
+    "@textlint/source-code-fixer": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-12.2.1.tgz",
+      "integrity": "sha512-yNkWcTxCcoz24b64rGUVDr2MzQdv3I1o2o7HuphCmGlAQztVzMGvY/GNzqUWW42+k8S0zRq3Saxz1XoMUvR5UA==",
+      "dev": true,
+      "requires": {
+        "@textlint/types": "^12.2.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "@textlint/text-to-ast": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-12.2.1.tgz",
+      "integrity": "sha512-NcuFa8iQglIMBQ1OaR1IYAIYJfBcTACVD0YtPGrdN0gkqC8TEfP5xIldiSxhkWiLPr3TQ4Mg7d6Ev5RH67n7pA==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^12.2.1"
+      }
+    },
+    "@textlint/textlint-plugin-markdown": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-12.2.1.tgz",
+      "integrity": "sha512-BAjkVPMO5fzf6n5M5SwgHNyTwByE86BmjaNpBDhKNcSBctUnfX7nLCvQY8mGMkvefHufyi3oWIqDcZoZQn0PYQ==",
+      "dev": true,
+      "requires": {
+        "@textlint/markdown-to-ast": "^12.2.1"
+      }
+    },
+    "@textlint/textlint-plugin-text": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-12.2.1.tgz",
+      "integrity": "sha512-8Dt1Sn9AdqvweVxCLvlj1IC+pDxPRpdgERY6FzD6kLNpMAyl7luVWtpql19CvTYlxhPUHRxsETDBkRCQFClXsw==",
+      "dev": true,
+      "requires": {
+        "@textlint/text-to-ast": "^12.2.1"
+      }
+    },
+    "@textlint/types": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-12.2.1.tgz",
+      "integrity": "sha512-nOQ3udAz9ulDZgETFY3vr3R+ubL2cevPLA3GmDs29ErvIHfK3pD+PpyO/OsS7HZKXolmpuMonVA9+J9Jybf3/Q==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^12.2.1"
+      }
+    },
+    "@textlint/utils": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-12.2.1.tgz",
+      "integrity": "sha512-e4jDM6bMZddFi48e5CzbvnG9ombeK2ZkjLnCaSWalJI3NTlCDm/ZDqfaqac/YPFbzoRQMqNkaoTW/9GZVjr6Hg==",
+      "dev": true
+    },
+    "@types/mdast": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
+      "integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
+    "@types/structured-source": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/structured-source/-/structured-source-3.0.0.tgz",
+      "integrity": "sha512-8u+Wo5+GEXe4jZyQ8TplLp+1A7g32ZcVoE7VZu8VcxnlaEm5I/+T579R7q3qKN76jmK0lRshpo4hl4bj/kEPKA==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "boundary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
+      "integrity": "sha512-AaLhxHwYVh55iOTJncV3DE5o7RakEUSSj64XXEWRTiIhlp7aDI8qR0vY/k8Uw0Z234VjZi/iG/WxfrvqYPUCww==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "ccount": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
+      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "dev": true
+    },
+    "character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "dev": true
+    },
+    "character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true
+    },
+    "clone-regexp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^2.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "dev": true
+    },
+    "commandpost": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.4.0.tgz",
+      "integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "requires": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "doublearray": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
+      "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "execall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+      "dev": true,
+      "requires": {
+        "clone-regexp": "^2.1.0"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "dev": true,
+      "requires": {
+        "format": "^0.2.0"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha512-jZV7n6jGE3Gt7fgSTJoz91Ak5MuTLwMwkoYdjxuJ/AmjIsE1UC03y/IWkZCQGEvVNS9qoRNwy5BCqxImv0FVeA==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "hast-util-from-parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
+      "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+      "dev": true,
+      "requires": {
+        "ccount": "^1.0.3",
+        "hastscript": "^5.0.0",
+        "property-information": "^5.0.0",
+        "web-namespaces": "^1.1.2",
+        "xtend": "^4.0.1"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "dev": true
+    },
+    "hastscript": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "dev": true,
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.0"
+      }
+    },
+    "is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "dev": true
+    },
+    "is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "dev": true,
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.0"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      }
+    },
+    "is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4"
+      }
+    },
+    "is-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-file/-/is-file-1.0.0.tgz",
+      "integrity": "sha512-ZGMuc+xA8mRnrXtmtf2l/EkIW2zaD2LSBWlaOVEF6yH4RTndHob65V4SwWWdtGKVthQfXPVKsXqw4TDUjbVxVQ==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
+    "kuromoji": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.1.tgz",
+      "integrity": "sha512-B7ctEuhoYzRDbgsRn/3NQVee/Q4WRFVuCxkYtnQLl+t/5tw2f7JL0GQH/CQQ3gqlaEvBJgfnGNA6st09wmqkRA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.0.1",
+        "doublearray": "0.0.2",
+        "zlibjs": "^0.2.0"
+      }
+    },
+    "kuromojin": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-2.1.1.tgz",
+      "integrity": "sha512-bd5dfE9CdRBoRPiquE5uhzBrDOn2K3WuFeOWqZgM7DNtQhvS7P9IALy5MtDxXcnw7DLBAZ1A7DByPO5BhXdgew==",
+      "dev": true,
+      "requires": {
+        "kuromoji": "0.1.1"
+      }
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true
+    },
+    "lodash.uniqwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+      "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==",
+      "dev": true
+    },
+    "longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "dev": true
+    },
+    "lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "dev": true
+    },
+    "markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dev": true,
+      "requires": {
+        "repeat-string": "^1.0.0"
+      }
+    },
+    "match-index": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/match-index/-/match-index-1.0.3.tgz",
+      "integrity": "sha512-1XjyBWqCvEFFUDW/MPv0RwbITRD4xQXOvKoPYtLDq8IdZTfdF/cQSo5Yn4qvhfSSZgjgkTFsqJD2wOUG4ovV8Q==",
+      "dev": true,
+      "requires": {
+        "regexp.prototype.flags": "^1.1.1"
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        }
+      }
+    },
+    "mdast-util-find-and-replace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+      "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^4.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      }
+    },
+    "mdast-util-footnote": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/mdast-util-footnote/-/mdast-util-footnote-0.1.7.tgz",
+      "integrity": "sha512-QxNdO8qSxqbO2e3m09KwDKfWiLgqyCurdWTQ198NpbZ2hxntdc+VKS4fDJCmNWbAroUdYnSthu+XbZ8ovh8C3w==",
+      "dev": true,
+      "requires": {
+        "mdast-util-to-markdown": "^0.6.0",
+        "micromark": "~2.11.0"
+      }
+    },
+    "mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "mdast-util-frontmatter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-0.2.0.tgz",
+      "integrity": "sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==",
+      "dev": true,
+      "requires": {
+        "micromark-extension-frontmatter": "^0.2.0"
+      }
+    },
+    "mdast-util-gfm": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+      "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
+      "dev": true,
+      "requires": {
+        "mdast-util-gfm-autolink-literal": "^0.1.0",
+        "mdast-util-gfm-strikethrough": "^0.2.0",
+        "mdast-util-gfm-table": "^0.1.0",
+        "mdast-util-gfm-task-list-item": "^0.1.0",
+        "mdast-util-to-markdown": "^0.6.1"
+      }
+    },
+    "mdast-util-gfm-autolink-literal": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+      "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
+      "dev": true,
+      "requires": {
+        "ccount": "^1.0.0",
+        "mdast-util-find-and-replace": "^1.1.0",
+        "micromark": "^2.11.3"
+      }
+    },
+    "mdast-util-gfm-strikethrough": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+      "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
+      "dev": true,
+      "requires": {
+        "mdast-util-to-markdown": "^0.6.0"
+      }
+    },
+    "mdast-util-gfm-table": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+      "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+      "dev": true,
+      "requires": {
+        "markdown-table": "^2.0.0",
+        "mdast-util-to-markdown": "~0.6.0"
+      }
+    },
+    "mdast-util-gfm-task-list-item": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+      "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+      "dev": true,
+      "requires": {
+        "mdast-util-to-markdown": "~0.6.0"
+      }
+    },
+    "mdast-util-to-markdown": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true
+    },
+    "micromark": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      }
+    },
+    "micromark-extension-footnote": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-footnote/-/micromark-extension-footnote-0.3.2.tgz",
+      "integrity": "sha512-gr/BeIxbIWQoUm02cIfK7mdMZ/fbroRpLsck4kvFtjbzP4yi+OPVbnukTc/zy0i7spC2xYE/dbX1Sur8BEDJsQ==",
+      "dev": true,
+      "requires": {
+        "micromark": "~2.11.0"
+      }
+    },
+    "micromark-extension-frontmatter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-0.2.2.tgz",
+      "integrity": "sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==",
+      "dev": true,
+      "requires": {
+        "fault": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+      "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
+      "dev": true,
+      "requires": {
+        "micromark": "~2.11.0",
+        "micromark-extension-gfm-autolink-literal": "~0.5.0",
+        "micromark-extension-gfm-strikethrough": "~0.6.5",
+        "micromark-extension-gfm-table": "~0.4.0",
+        "micromark-extension-gfm-tagfilter": "~0.3.0",
+        "micromark-extension-gfm-task-list-item": "~0.3.0"
+      }
+    },
+    "micromark-extension-gfm-autolink-literal": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+      "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
+      "dev": true,
+      "requires": {
+        "micromark": "~2.11.3"
+      }
+    },
+    "micromark-extension-gfm-strikethrough": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+      "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
+      "dev": true,
+      "requires": {
+        "micromark": "~2.11.0"
+      }
+    },
+    "micromark-extension-gfm-table": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+      "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
+      "dev": true,
+      "requires": {
+        "micromark": "~2.11.0"
+      }
+    },
+    "micromark-extension-gfm-tagfilter": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+      "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
+      "dev": true
+    },
+    "micromark-extension-gfm-task-list-item": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+      "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
+      "dev": true,
+      "requires": {
+        "micromark": "~2.11.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.6"
+      }
+    },
+    "moji": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moji/-/moji-0.5.1.tgz",
+      "integrity": "sha512-xYylXOjBS9mE/d690InK3Y74NpE0El0TmAKDmKJveWk9jds/0Tl7MQP4yhavS0U64diEq+5ey2905nhCpIHE+Q==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^3.0.0"
+      }
+    },
+    "morpheme-match": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-1.2.1.tgz",
+      "integrity": "sha512-SSIcFPas4Dctx5PbrfKbW5XNADlkcn38LI+fqgB9QtminQ7FXeOR3//rnAmooZ1/5zTGeFoi8H9kFBAH9y1nfQ==",
+      "dev": true
+    },
+    "morpheme-match-all": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/morpheme-match-all/-/morpheme-match-all-1.2.0.tgz",
+      "integrity": "sha512-z8F1k4U8fAMcjkGBDWwVrKZLR8VSvKtYh6+5GZ9hi5mtXrYMILwDMgiPwfNGJvk/liQEG9/oNAJUcwLpyjI9Xg==",
+      "dev": true,
+      "requires": {
+        "morpheme-match": "^1.2.1"
+      }
+    },
+    "morpheme-match-textlint": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/morpheme-match-textlint/-/morpheme-match-textlint-2.0.6.tgz",
+      "integrity": "sha512-CX+iQaUjjPMLvas+hZ8zg6Csxx5j1RLaytr+5w6lpBi/oTEV2pv6sgW5Vu3+pNJHbYcaqcuofQZsKocMNUNH8g==",
+      "dev": true,
+      "requires": {
+        "morpheme-match": "^2.0.4",
+        "morpheme-match-all": "^2.0.5"
+      },
+      "dependencies": {
+        "morpheme-match": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-2.0.4.tgz",
+          "integrity": "sha512-C3U5g2h47dpztGVePLA8w2O1aQEvuJORwIcahWaCG91YPrq+0u7qcPsF9Nqqe8noFvHwgO7b2EEk3iPnYuGTew==",
+          "dev": true
+        },
+        "morpheme-match-all": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/morpheme-match-all/-/morpheme-match-all-2.0.5.tgz",
+          "integrity": "sha512-a6B6Nh4AhjMoEzVz8NOT5M9f3XwFVPM395gqnFNUXG/KTqQFTb9qM5JJFHJe+SvWfRVXTZSejyXNt+h+jmHUuQ==",
+          "dev": true,
+          "requires": {
+            "morpheme-match": "^2.0.4"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "dev": true
+    },
+    "parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "dev": true,
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "path-to-glob-pattern": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-to-glob-pattern/-/path-to-glob-pattern-1.0.2.tgz",
+      "integrity": "sha512-ryF65N5MBB9XOjE5mMOi+0bMrh1F0ORQmqDSSERvv5zD62Cfc5QC6rK1AR1xuDIG1I091CkNENblbteWy1bXgw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pluralize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+      "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prh": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/prh/-/prh-5.4.4.tgz",
+      "integrity": "sha512-UATF+R/2H8owxwPvF12Knihu9aYGTuZttGHrEEq5NBWz38mREh23+WvCVKX3fhnIZIMV7ye6E1fnqAl+V6WYEw==",
+      "dev": true,
+      "requires": {
+        "commandpost": "^1.2.1",
+        "diff": "^4.0.1",
+        "js-yaml": "^3.9.1"
+      }
+    },
+    "property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "rc-config-loader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-3.0.0.tgz",
+      "integrity": "sha512-bwfUSB37TWkHfP+PPjb/x8BUjChFmmBK44JMfVnU7paisWqZl/o5k7ttCH+EQLnrbn2Aq8Fo1LAsyUiz+WF4CQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "js-yaml": "^3.12.0",
+        "json5": "^2.1.1",
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+          "dev": true
+        }
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "rehype-parse": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
+      "integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+      "dev": true,
+      "requires": {
+        "hast-util-from-parse5": "^5.0.0",
+        "parse5": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "remark-footnotes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-3.0.0.tgz",
+      "integrity": "sha512-ZssAvH9FjGYlJ/PBVKdSmfyPc3Cz4rTWgZLI4iE/SX8Nt5l3o3oEjv3wwG5VD7xOjktzdwp5coac+kJV9l4jgg==",
+      "dev": true,
+      "requires": {
+        "mdast-util-footnote": "^0.1.0",
+        "micromark-extension-footnote": "^0.3.0"
+      }
+    },
+    "remark-frontmatter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-3.0.0.tgz",
+      "integrity": "sha512-mSuDd3svCHs+2PyO29h7iijIZx4plX0fheacJcAoYAASfgzgVIcXGYSq9GFyYocFLftQs8IOmmkgtOovs6d4oA==",
+      "dev": true,
+      "requires": {
+        "mdast-util-frontmatter": "^0.2.0",
+        "micromark-extension-frontmatter": "^0.2.0"
+      }
+    },
+    "remark-gfm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+      "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
+      "dev": true,
+      "requires": {
+        "mdast-util-gfm": "^0.1.0",
+        "micromark-extension-gfm": "^0.3.0"
+      }
+    },
+    "remark-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "dev": true,
+      "requires": {
+        "mdast-util-from-markdown": "^0.8.0"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "structured-source": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
+      "integrity": "sha512-Ap7JHfKgmH40SUjumqyKTHYHNZ8GvGQskP34ks0ElHCDEig+bYGpmXVksxPSrgcY9rkJqhVMzfeg5GIpZelfpQ==",
+      "dev": true,
+      "requires": {
+        "boundary": "^1.0.1"
+      }
+    },
+    "sudachi-synonyms-dictionary": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/sudachi-synonyms-dictionary/-/sudachi-synonyms-dictionary-10.0.0.tgz",
+      "integrity": "sha512-Ci+5Ps7QeyexSZJ5Op84O5D7NDv2V8fEeY/H3pLkYr/mpM8RpYF5PhCF3jaFsb9IqbX8q01WTrE5WhLuD7Twwg==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
+    "table": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "textlint": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/textlint/-/textlint-12.2.1.tgz",
+      "integrity": "sha512-e6xKNLbTt10KbnG0x3eVE7l8A7uOC9bj0Hc8cWk6VoLffjrdw4o8kJjWVIspNzfb0kUEs2dBKgXZo0ob4tMWAg==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^12.2.1",
+        "@textlint/ast-traverse": "^12.2.1",
+        "@textlint/feature-flag": "^12.2.1",
+        "@textlint/fixer-formatter": "^12.2.1",
+        "@textlint/kernel": "^12.2.1",
+        "@textlint/linter-formatter": "^12.2.1",
+        "@textlint/module-interop": "^12.2.1",
+        "@textlint/textlint-plugin-markdown": "^12.2.1",
+        "@textlint/textlint-plugin-text": "^12.2.1",
+        "@textlint/types": "^12.2.1",
+        "@textlint/utils": "^12.2.1",
+        "debug": "^4.3.4",
+        "deep-equal": "^1.1.1",
+        "file-entry-cache": "^5.0.1",
+        "get-stdin": "^5.0.1",
+        "glob": "^7.2.3",
+        "is-file": "^1.0.0",
+        "md5": "^2.3.0",
+        "mkdirp": "^0.5.6",
+        "optionator": "^0.9.1",
+        "path-to-glob-pattern": "^1.0.2",
+        "rc-config-loader": "^3.0.0",
+        "read-pkg": "^1.1.0",
+        "read-pkg-up": "^3.0.0",
+        "structured-source": "^3.0.2",
+        "try-resolve": "^1.0.1",
+        "unique-concat": "^0.2.2"
+      }
+    },
+    "textlint-rule-helper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.2.1.tgz",
+      "integrity": "sha512-pdX3uNbFzQTgINamaBpEHRT/MgROHev5wCnQnUTXRLT5DaRjls0Rmpi5d1MPZG6HT5NKVL++Q2J0FUbh5shi3Q==",
+      "dev": true,
+      "requires": {
+        "structured-source": "^3.0.2",
+        "unist-util-visit": "^2.0.3"
+      }
+    },
+    "textlint-rule-ja-hiragana-keishikimeishi": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-hiragana-keishikimeishi/-/textlint-rule-ja-hiragana-keishikimeishi-1.1.0.tgz",
+      "integrity": "sha512-rNwTzQdwGopLxesjXMYQi1MVzZbQOx7fap7dAcbajtvMCKMtucYcvOIptgegagpHctaRa303NqbHLhqMv3OIeg==",
+      "dev": true,
+      "requires": {
+        "kuromojin": "^2.1.1",
+        "morpheme-match-all": "^1.1.0"
+      }
+    },
+    "textlint-rule-ja-no-abusage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-abusage/-/textlint-rule-ja-no-abusage-3.0.0.tgz",
+      "integrity": "sha512-DIqPZgYTwTsvjX6Bgj7GA8vlwGMObagJpNoUtkucOaoy7E7GwUOL+knqFjcTtlkWSmoKpIkw5OWW5CV3kivlfQ==",
+      "dev": true,
+      "requires": {
+        "kuromojin": "^3.0.0",
+        "morpheme-match-textlint": "^2.0.6",
+        "textlint-rule-prh": "^5.3.0"
+      },
+      "dependencies": {
+        "kuromoji": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+          "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+          "dev": true,
+          "requires": {
+            "async": "^2.0.1",
+            "doublearray": "0.0.2",
+            "zlibjs": "^0.3.1"
+          }
+        },
+        "kuromojin": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-3.0.0.tgz",
+          "integrity": "sha512-3h3qnn/NVVhqoKFP4oc7e6apO2B01Atc056oiVlIY7Uoup4rhrnBe28g3y9lK1HTmLDQEejvXB+3I3qxAneF7A==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.2",
+            "lru_map": "^0.4.1"
+          }
+        },
+        "zlibjs": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+          "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+          "dev": true
+        }
+      }
+    },
+    "textlint-rule-ja-no-redundant-expression": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-redundant-expression/-/textlint-rule-ja-no-redundant-expression-4.0.1.tgz",
+      "integrity": "sha512-r8Qe6S7u9N97wD0gcrASqBUdZs5CMEVlgc8Ul+D2NQFiOi1BoseOMo5I9yUsEZMAL46yh/eaw9+EWz6IDlPWeA==",
+      "dev": true,
+      "requires": {
+        "@textlint/regexp-string-matcher": "^1.1.0",
+        "kuromojin": "^3.0.0",
+        "morpheme-match": "^2.0.4",
+        "morpheme-match-all": "^2.0.5",
+        "textlint-rule-helper": "^2.2.1",
+        "textlint-util-to-string": "^3.1.1"
+      },
+      "dependencies": {
+        "kuromoji": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+          "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+          "dev": true,
+          "requires": {
+            "async": "^2.0.1",
+            "doublearray": "0.0.2",
+            "zlibjs": "^0.3.1"
+          }
+        },
+        "kuromojin": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-3.0.0.tgz",
+          "integrity": "sha512-3h3qnn/NVVhqoKFP4oc7e6apO2B01Atc056oiVlIY7Uoup4rhrnBe28g3y9lK1HTmLDQEejvXB+3I3qxAneF7A==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.2",
+            "lru_map": "^0.4.1"
+          }
+        },
+        "morpheme-match": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-2.0.4.tgz",
+          "integrity": "sha512-C3U5g2h47dpztGVePLA8w2O1aQEvuJORwIcahWaCG91YPrq+0u7qcPsF9Nqqe8noFvHwgO7b2EEk3iPnYuGTew==",
+          "dev": true
+        },
+        "morpheme-match-all": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/morpheme-match-all/-/morpheme-match-all-2.0.5.tgz",
+          "integrity": "sha512-a6B6Nh4AhjMoEzVz8NOT5M9f3XwFVPM395gqnFNUXG/KTqQFTb9qM5JJFHJe+SvWfRVXTZSejyXNt+h+jmHUuQ==",
+          "dev": true,
+          "requires": {
+            "morpheme-match": "^2.0.4"
+          }
+        },
+        "zlibjs": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+          "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+          "dev": true
+        }
+      }
+    },
+    "textlint-rule-ja-space-around-code": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-2.2.0.tgz",
+      "integrity": "sha512-JJfnSTFJCBL618TYVMqFfil8r7MhZuY0tEg2kyD6k/gcjbYFBx050pEl/RJJ5uD3UShLV7y4t289Gg9zuNjklw==",
+      "dev": true,
+      "requires": {
+        "match-index": "^1.0.1",
+        "textlint-rule-helper": "^2.2.0"
+      }
+    },
+    "textlint-rule-ja-space-between-half-and-full-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-2.2.0.tgz",
+      "integrity": "sha512-/NJb0FrBa0qx/Z1SuW1nE0dhERCRNxz8IkdZ8V3VPxtZIaeBbPLdYxLf7h5qJnEAapqSd85pvZ4EXZI3RArvYw==",
+      "dev": true,
+      "requires": {
+        "match-index": "^1.0.1",
+        "textlint-rule-helper": "^2.2.0"
+      }
+    },
+    "textlint-rule-max-kanji-continuous-len": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-max-kanji-continuous-len/-/textlint-rule-max-kanji-continuous-len-1.1.1.tgz",
+      "integrity": "sha512-os+p7dS9Op4PtZV7B9/wnzN5qpDO2WR2kj7nTnqEPbApS06AXX+qf5eH3fKdm4blzUCcPF5ozMN8zbs3AJUAug==",
+      "dev": true,
+      "requires": {
+        "match-index": "^1.0.1",
+        "textlint-rule-helper": "^2.0.0"
+      }
+    },
+    "textlint-rule-no-dropping-the-ra": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-dropping-the-ra/-/textlint-rule-no-dropping-the-ra-3.0.0.tgz",
+      "integrity": "sha512-KbSIlcxj1kLs4sGSMSLGA8OmgRoaPAWtodJaGEyEUiy7uiZM/VPqYALpuD8vf16N1OR5SM/bXXeZFME65r8ZgQ==",
+      "dev": true,
+      "requires": {
+        "kuromojin": "^3.0.0",
+        "textlint-rule-helper": "^2.1.1"
+      },
+      "dependencies": {
+        "kuromoji": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+          "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+          "dev": true,
+          "requires": {
+            "async": "^2.0.1",
+            "doublearray": "0.0.2",
+            "zlibjs": "^0.3.1"
+          }
+        },
+        "kuromojin": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-3.0.0.tgz",
+          "integrity": "sha512-3h3qnn/NVVhqoKFP4oc7e6apO2B01Atc056oiVlIY7Uoup4rhrnBe28g3y9lK1HTmLDQEejvXB+3I3qxAneF7A==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.2",
+            "lru_map": "^0.4.1"
+          }
+        },
+        "zlibjs": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+          "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+          "dev": true
+        }
+      }
+    },
+    "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet/-/textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet-1.0.1.tgz",
+      "integrity": "sha512-jRiBtdslvtFNgWhCT1FZW0Ct5lfO3Af39iKJV20hxOZMhxM0sz+pnfmooEQ9wpAQm5kL+W1kJoX2O9uKw01AvA==",
+      "dev": true,
+      "requires": {
+        "match-index": "^1.0.1",
+        "moji": "^0.5.1",
+        "textlint-rule-helper": "^2.0.0"
+      }
+    },
+    "textlint-rule-prh": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-5.3.0.tgz",
+      "integrity": "sha512-gdod+lL1SWUDyXs1ICEwvQawaSshT3mvPGufBIjF2R5WFPdKQDMsiuzsjkLm+aF+9d97dA6pFsiyC8gSW7mSgg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.7.5",
+        "prh": "^5.4.4",
+        "textlint-rule-helper": "^2.1.1",
+        "untildify": "^3.0.3"
+      }
+    },
+    "textlint-util-to-string": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-3.1.1.tgz",
+      "integrity": "sha512-mHE7/pDw/Hk+Q6YdSMNRrZPl5bCuWnFLbF+bxW+MsWQ64dw+Ia9irkammYbH5I0hVMMcfwb0MQc5nbsjqgWeyQ==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^4.2.4",
+        "@types/structured-source": "^3.0.0",
+        "rehype-parse": "^6.0.1",
+        "structured-source": "^3.0.2",
+        "unified": "^8.4.0"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.4.3.tgz",
+          "integrity": "sha512-qi2jjgO6Tn3KNPGnm6B7p6QTEPvY95NFsIAaJuwbulur8iJUEenp1OnoUfiDaC/g2WPPEFkcfXpmnu8XEMFo2A==",
+          "dev": true
+        },
+        "unified": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+          "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+          "dev": true,
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        }
+      }
+    },
+    "tiny-segmenter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-segmenter/-/tiny-segmenter-0.2.0.tgz",
+      "integrity": "sha512-m+aTJQ/CUBKurLaJRpLmJiwcL+Gpkzft5ZYnRU9AkuO45Y/k/2iJmuLEbN1XLrq6N3kDVyIUCCeqRzQx0feBag==",
+      "dev": true
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
+      "dev": true
+    },
+    "trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true
+    },
+    "try-resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+      "integrity": "sha512-yHeaPjCBzVaXwWl5IMUapTaTC2rn/eBYg2fsG2L+CvJd+ttFbk0ylDnpTO3wVhosmE1tQEvcebbBeKLCwScQSQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "unified": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
+      "dev": true,
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      }
+    },
+    "unique-concat": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/unique-concat/-/unique-concat-0.2.2.tgz",
+      "integrity": "sha512-nFT3frbsvTa9rrc71FJApPqXF8oIhVHbX3IWgObQi1mF7WrW48Ys70daL7o4evZUtmUf6Qn6WK0LbHhyO0hpXw==",
+      "dev": true
+    },
+    "unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "dev": true
+    },
+    "unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
+    "unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      }
+    },
+    "untildify": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vfile": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      }
+    },
+    "vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "web-namespaces": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+      "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "xml-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+      "integrity": "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
+    "zlibjs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.2.0.tgz",
+      "integrity": "sha512-UA5w5YE92YlkBgr2qk4G3rNrOskQqHy0b/vhlU1U+MKeEHAASJ787MiXBUUsEuHO5t0pwKZ7VOAEJMJhLXcJsg==",
+      "dev": true
+    },
+    "zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "wordpress-textlint",
+  "version": "1.0.0",
+  "description": "WordPress プロジェクト の textlint",
+  "main": "index.js",
+  "scripts": {
+    "textlint": "textlint",
+    "lint": "textlint ./core/**/*.md"
+  },
+  "devDependencies": {
+    "@textlint-ja/textlint-rule-no-synonyms": "^1.3.0",
+    "sudachi-synonyms-dictionary": "^10.0.0",
+    "textlint": "^12.2.1",
+    "textlint-rule-ja-hiragana-keishikimeishi": "^1.1.0",
+    "textlint-rule-ja-no-abusage": "^3.0.0",
+    "textlint-rule-ja-no-redundant-expression": "^4.0.1",
+    "textlint-rule-ja-space-around-code": "^2.2.0",
+    "textlint-rule-ja-space-between-half-and-full-width": "^2.2.0",
+    "textlint-rule-max-kanji-continuous-len": "^1.1.1",
+    "textlint-rule-no-dropping-the-ra": "^3.0.0",
+    "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "^1.0.1",
+    "textlint-rule-prh": "^5.3.0"
+  }
+}

--- a/prh-rules/wordpress.yml
+++ b/prh-rules/wordpress.yml
@@ -1,0 +1,2642 @@
+# Rules for WordPress
+meta:
+  reviewer:
+    - keichan34
+  related: https://github.com/jawordpressorg/
+  rules:
+
+version: 1
+
+# WEB+DB_PRESS のルールを参考に
+# https://github.com/prh/rules/blob/master/media/WEB+DB_PRESS.yml
+#
+# WordPress Glossary と翻訳ガイドラインのルールを追加しました。
+#
+# https://translate.wordpress.org/locale/ja/default/glossary
+# https://ja.wordpress.org/team/handbook/translation/translation-style-guide/
+
+rules:
+  # 全角スペース、半角スペースの連続を禁止
+  - pattern: "　"
+    expected: " "
+  - pattern: "  "
+    expected: " "
+  # 英数字は半角文字を使う
+  - pattern: ０
+    expected: "0"
+  - pattern: １
+    expected: "1"
+  - pattern: ２
+    expected: "2"
+  - pattern: ３
+    expected: "3"
+  - pattern: ４
+    expected: "4"
+  - pattern: ５
+    expected: "5"
+  - pattern: ６
+    expected: "6"
+  - pattern: ７
+    expected: "7"
+  - pattern: ８
+    expected: "8"
+  - pattern: ９
+    expected: "9"
+  # 符号、疑問符、感嘆符、丸括弧、コロンには半角文字を使う
+  - pattern: ＋
+    expected: "+"
+  - pattern: －
+    expected: "-"
+  - pattern: ＝
+    expected: "="
+  - pattern: ＜
+    expected: "<"
+  - pattern: ＞
+    expected: ">"
+  - pattern: ？
+    expected: "?"
+  - pattern: ！
+    expected: "!"
+  - pattern: （
+    expected: (
+  - pattern: ）
+    expected: )
+  - pattern: ：
+    expected: ":"
+  # 半角英字と全角文字の間には、半角スペースを入れる
+  - pattern: /([^\x01-\x7E])([a-zA-Z]+)([^\x01-\x7E])/
+    expected: $1 $2 $3
+  # 疑問符、感嘆符の前に半角スペースを入れる
+  - pattern: /([^ ])([!?])/
+    expected: $1 $2
+  # 丸括弧の内側に半角スペースを入れない
+  - pattern: /\( (.)/
+    expected: ($1
+  - pattern: /(.) \)/
+    expected: $1)
+  # 丸括弧の前に半角スペースを入れる (例外として。、は除く)
+  - pattern: /([^ 。、])\(/
+    expected: $1 (
+  # 丸括弧の前に半角スペースを入れない (。、)
+  - pattern: /([。、]) \(/
+    expected: $1(
+  # 丸括弧の後に半角スペースを入れる (例外として。、は除く)
+  - pattern: /\)([^ 。、\n\r\n\r])/
+    expected: ) $1
+  # 丸括弧の後に半角スペースを入れない (。、)
+  - pattern: /\) ([。、])/
+    expected: )$1
+  # コロンの前に半角スペースを入れない
+  - pattern: /(.) :/
+    expected: "$1:"
+  # コロンの後に半角スペースを入れる
+  - pattern: /:([^ ])/
+    expected: ": $1"
+  # 丸括弧内には句点は付けない
+  - pattern: 。)
+    expected: )
+  # 半角数字の前後には半角スペースを入れない
+  - pattern: /(.) ([0-9]) (.)/
+    expected: $1$2$3
+  - pattern: /(.)([0-9]) (.)/
+    expected: $1$2$3
+  - pattern: /(.) ([0-9])(.)/
+    expected: $1$2$3
+  - pattern: /^[^#] \)$/
+    expected: ああああ
+
+  - pattern: /つく([らりるれろっ])/
+    expected: 作$1
+  - pattern:
+      - 結びつ
+      - むすびつ
+    expected: 結び付
+  - pattern:
+      - 受けつ
+      - うけつ
+    expected: 受け付
+  - pattern:
+      - 受けと
+      - うけと
+    expected: 受け取
+  - pattern: 日付け
+    expected: 日付
+  - pattern: つきあ
+    expected: 付き合
+  - pattern:
+      - つけ加
+      - つけくわ
+    expected: 付け加
+  - pattern: つけた
+    expected: 付け足
+  - pattern: 関連づけ
+    expected: 関連付け
+  - pattern: 受付
+    expected: 受け付け
+  - pattern: 位置づけ
+    expected: 位置付け
+  - pattern: 意味づけ
+    expected: 意味付け
+  - pattern: 気をつ
+    expected: 気を付
+  - pattern: 気づ
+    expected: 気付
+  - pattern: 近づ
+    expected: 近付
+  - pattern:
+      - 検討がつ
+      - 検討がつ
+    expected: 見当が付
+  - pattern: 思いつく
+    expected: 思い付く
+  - pattern:
+      - 1つ1つ
+      - 一つひとつ
+      - ひとつひとつ
+    expected: 一つ一つ
+  - pattern:
+      - 一人ひとり
+      - ひとりひとり
+      - 1人1人
+    expected: 一人一人
+  - pattern:
+      - 一つめ
+      - ひとつめ
+      - 一つ目
+      - ひとつ目
+    expected: 1つ目
+  - pattern:
+      - 二つめ
+      - ふたつめ
+      - 二つ目
+      - ふたつ目
+    expected: 2つ目
+  - pattern:
+      - 三つめ
+      - みっつめ
+      - 三つ目
+      - みっつ目
+    expected: 3つ目
+  - pattern:
+      - 四つめ
+      - よっつめ
+      - 四つ目
+      - よっつ目
+    expected: 4つ目
+  - pattern:
+      - 五つめ
+      - いつつめ
+      - 五つ目
+      - いつつ目
+    expected: 5つ目
+  - pattern:
+      - 六つめ
+      - むっつめ
+      - 六つ目
+      - むっつ目
+    expected: 6つ目
+  - pattern:
+      - 七つめ
+      - ななつめ
+      - 七つ目
+      - ななつ目
+    expected: 7つ目
+  - pattern:
+      - 八つめ
+      - やっつめ
+      - 八つ目
+      - やっつ目
+    expected: 8つ目
+  - pattern:
+      - 九つめ
+      - ここのつめ
+      - 九つ目
+      - ここのつ目
+    expected: 9つ目
+  - pattern:
+      - 一番目
+      - 一番め
+    expected: 1番目
+  - pattern:
+      - 二番目
+      - 二番め
+    expected: 2番目
+  - pattern:
+      - 三番目
+      - 三番め
+    expected: 3番目
+  - pattern:
+      - 四番目
+      - 四番め
+    expected: 4番目
+  - pattern:
+      - 五番目
+      - 五番め
+    expected: 5番目
+  - pattern:
+      - 六番目
+      - 六番め
+    expected: 6番目
+  - pattern:
+      - 七番目
+      - 七番め
+    expected: 7番目
+  - pattern:
+      - 八番目
+      - 八番め
+    expected: 8番目
+  - pattern:
+      - 九番目
+      - 九番め
+    expected: 9番目
+  - pattern:
+      - 十番目
+      - 十番め
+    expected: 10番目
+  - pattern:
+      - ふたつ
+      - 二つ
+    expected: 2つ
+  - pattern:
+      - みっつ
+      - 三つ
+    expected: 3つ
+  - pattern:
+      - よっつ
+      - 四つ
+    expected: 4つ
+  - pattern:
+      - いつつ
+      - 五つ
+    expected: 5つ
+  - pattern:
+      - むっつ
+      - 六つ
+    expected: 6つ
+  - pattern:
+      - ななつ
+      - 七つ
+    expected: 7つ
+  - pattern:
+      - やっつ
+      - 八つ
+    expected: 8つ
+  - pattern:
+      - ここのつ
+      - 九つ
+    expected: 9つ
+  - pattern: /([\d]+)つめ
+    expected: $1つ目
+  - pattern: /([\d]+)番め/
+    expected: $1番目
+  - pattern: /いちばん([^め目])|1番([^め目])/
+    expected: 一番$1
+  - pattern:
+      - ただ1つ
+      - 唯1つ
+      - 唯一つ
+    expected: ただ一つ
+  - pattern: もう1度
+    expected: もう一度
+  - pattern: もう1つ
+    expected: もう一つ
+  - pattern: 1つは
+    expected: 一つは
+  - pattern: 一目了然
+    expected: 一目瞭然
+  - pattern: いちがいに
+    expected: 一概に
+  - pattern: 一種類
+    expected: 1種類
+  - pattern: 1種
+    expected: 一種
+  - pattern: いっしょ
+    expected: 一緒
+  - pattern:
+      - ひととおり
+      - ひと通り
+      - 一とおり
+    expected: 一通り
+  - pattern: 1度
+    expected: 一度
+  - pattern: 1部
+    expected: 一部
+  - pattern: 1文
+    expected: 一文
+  - pattern: 1例
+    expected: 一例
+  - pattern: 2重
+    expected: 二重
+  - pattern: 3重
+    expected: 三重
+  - pattern: /([何数\\d一二三四五六七八九十０-９])箇所/
+    expected: $1ヵ所
+  - pattern: /([何数\\d一二三四五六七八九十０-９])個所/
+    expected: $1ヵ所
+  - pattern: ヶ
+    expected: ヵ
+  - pattern:
+      - 箇月
+      - か月
+      - 個月
+      - ケ月
+      - カ月
+    expected: ヵ月
+  - pattern:
+      - 箇国
+      - か国
+      - 個国
+      - ケ国
+      - カ国
+    expected: ヵ国
+  - pattern:
+      - か所
+      - ケ所
+      - カ所
+    expected: ヵ所
+  - pattern: 個所
+    expected: 箇所
+  - pattern:
+      - いちから
+      - 1から
+      - 一から
+      - イチから
+      - 0から
+    expected: ゼロから
+  - pattern: 曖昧
+    expected: あいまい
+  - pattern: 敢えて
+    expected: あえて
+  - pattern: /煽([らりるれろっ])/
+    expected: あお$1
+  - pattern: 飽くまで
+    expected: あくまで
+  - pattern: 憧れ
+    expected: あこがれ
+  - pattern: 辺り
+    expected: あたり
+  - pattern: 後々
+    expected: あとあと
+  - pattern:
+      - 貴方
+      - 貴女
+    expected: あなた
+  - pattern: 予め
+    expected: あらかじめ
+  - pattern: 改めて
+    expected: あらためて
+  - pattern:
+      - 有り難
+      - 有難
+    expected: ありがた
+  - pattern: 有りま
+    expected: ありま
+  - pattern: 或いは
+    expected: あるいは
+  - pattern:
+      - 有る
+      - 在る
+    expected: ある
+  - pattern: /一体([^に化感])/
+    expected: いったい$1
+  - pattern: 一向に
+    expected: いっこうに
+  - pattern: 一旦
+    expected: いったん
+  - pattern: 如何
+    expected: いかが
+  - pattern: 如何に
+    expected: いかに
+  - pattern:
+      - ゆきま
+      - 行きま
+    expected: いきま
+  - pattern: 幾つ
+    expected: いくつ
+  - pattern: 幾ら
+    expected: いくら
+  - pattern: 幾分
+    expected: いくぶん
+  - pattern: 些か
+    expected: いささか
+  - pattern:
+      - 何れ
+      - いづれ
+    expected: いずれ
+  - pattern: /頂([いかきくけこ])|戴([いかきくけこ])/
+    expected: いただ$1
+  - pattern: 至って
+    expected: いたって
+  - pattern: 一々
+    expected: いちいち
+  - pattern: /何時([^間])/
+    expected: いつ$1
+  - pattern: 一杯
+    expected: いっぱい
+  - pattern: /厭([わいうえおっ])/
+    expected: いと$1
+  - pattern: おります
+    expected: います
+  - pattern: 今や
+    expected: いまや
+  - pattern: 色々
+    expected: いろいろ
+  - pattern: 色んな
+    expected: いろんな
+  - pattern: 所謂
+    expected: いわゆる
+  - pattern: ゆう
+    expected: いう
+  - pattern: /云([いうわっ])/
+    expected: い$1
+  - pattern: /要([らりるれろっ])/
+    expected: い$1
+  - pattern: /居([るた])/
+    expected: い$1
+  - pattern: /穿([たちつてとっ])/
+    expected: うが$1
+  - pattern:
+      - 憂っとおし
+      - 憂っとうし
+      - うっとおし
+      - 鬱陶し
+    expected: うっとうし
+  - pattern:
+      - うなづ
+      - 頷
+    expected: うなず
+  - pattern: /上手([いく])|美味([いく])|ウマ([いく])/
+    expected: うま$1
+  - pattern: 嬉し
+    expected: うれし
+  - pattern: 美味し
+    expected: おいし
+  - pattern: 於いて
+    expected: おいて
+  - pattern: 大掛かり
+    expected: おおがかり
+  - pattern: 概ね
+    expected: おおむね
+  - pattern:
+      - お陰
+      - 御陰
+    expected: おかげ
+  - pattern:
+      - 押し並べて
+      - 押しなべて
+    expected: おしなべて
+  - pattern: 自ずと
+    expected: おのずと
+  - pattern: 恐らく
+    expected: おそらく
+  - pattern: お疲れ様
+    expected: お疲れさま
+  - pattern: 面白
+    expected: おもしろ
+  - pattern: 却って
+    expected: かえって
+  - pattern: 片仮名
+    expected: カタカナ
+  - pattern: 且つ
+    expected: かつ
+  - pattern: /叶([わいうえおっ])/
+    expected: かな$1
+  - pattern: 仮名
+    expected: かな
+  - pattern: /構([いうわっ])/
+    expected: かま$1
+  - pattern: /痒([いかくさみ])/
+    expected: かゆ$1
+  - pattern:
+      - 綺麗
+      - 奇麗
+    expected: きれい
+  - pattern: /括([らりるれろっ])/
+    expected: くく$1
+  - pattern: 下さい
+    expected: ください
+# 一旦解除
+#  - pattern: /([^解])決して|([^解])けして/
+#    expected: $1けっして
+  - pattern: /拘([らりるれろっ])/
+    expected: こだわ$1
+  - pattern: 諺
+    expected: ことわざ
+  - pattern: 零れ
+    expected: こぼれ
+  - pattern: この章
+    expected: 本章
+  - pattern: /この様([なに])/
+    expected: このよう$1
+  - pattern: 年頃
+    expected: 年ごろ
+  - pattern: 歳頃
+    expected: 歳ごろ
+  - pattern: 日頃
+    expected: 日ごろ
+  - pattern: 頃
+    expected: ころ
+  - pattern: /遡([らりるれろっ])/
+    expected: さかのぼ$1
+  - pattern: さしづめ
+    expected: さしずめ
+  - pattern: 流石
+    expected: さすが
+  - pattern: 早速
+    expected: さっそく
+  - pattern: /捌([いかきくけこ])/
+    expected: さば$1
+  - pattern: 様々
+    expected: さまざま
+  - pattern: /晒([さしすせそ])/
+    expected: さら$1
+  - pattern: 仕掛け
+    expected: しかけ
+  - pattern: 仕方
+    expected: しかた
+  - pattern: /([^正率垂安素愚])直に/
+    expected: $1じかに
+  - pattern: /仕組([^み])/
+    expected: しくみ$1
+  - pattern: 仕組み
+    expected: しくみ
+  - pattern: しし
+    expected: し
+  - pattern: しだい
+    expected: 次第
+  - pattern:
+      - 暫く
+      - 暫らく
+    expected: しばらく
+  - pattern: いたします
+    expected: します
+  - pattern: 所詮
+    expected: しょせん
+  - pattern:
+      - しようがない
+      - 仕様がない
+    expected: しょうがない
+  - pattern: 知れない
+    expected: しれない
+  - pattern: 知れません
+    expected: しれません
+  - pattern: 随分
+    expected: ずいぶん
+  - pattern: 直ぐ
+    expected: すぐ
+  - pattern: づくめ
+    expected: ずくめ
+  - pattern: /凄([いかくけ])/
+    expected: すご$1
+  - pattern: づつ
+    expected: ずつ
+  - pattern: 既に
+    expected: すでに
+  - pattern:
+      - すなはち
+      - 即ち
+    expected: すなわち
+  - pattern:
+      - 素晴らし
+      - 素晴し
+    expected: すばらし
+  - pattern: 素早
+    expected: すばや
+  - pattern: 須らく
+    expected: すべからく
+  - pattern: 折角
+    expected: せっかく
+  - pattern: 是非
+    expected: ぜひ
+  - pattern: そうゆう
+    expected: そういう
+  - pattern: 其々
+    expected: それぞれ
+  - pattern: 其れ
+    expected: それ
+  - pattern: /揃([わいうえおっ])/
+    expected: そろ$1
+# このあたりはどちらもありかな？一旦解除
+#    - pattern: 大体
+#    expected: だいたい
+#  - pattern: 大抵
+#    expected: たいてい
+#  - pattern: 大変
+#    expected: たいへん
+#  - pattern: 沢山
+#    expected: たくさん
+  - pattern:
+      - 高々
+      - 高高
+      - 高だか
+    expected: たかだか
+  - pattern: /叩([かきくけこ])/
+    expected: たた$1
+  - pattern: 但し
+    expected: ただし
+  - pattern: 直ち
+    expected: ただち
+  - pattern: 著者|私
+    expected: 筆者
+  - pattern: /辿([らりるれろっ])/
+    expected: たど$1
+  # 一貫性は必要なものの、両方よく出てくるので漢字またはひらがな NG は厳しすぎる気がするのでひとまず解除
+  # - pattern: 例えば
+  #  expected: たとえば
+  - pattern:
+      - 譬え
+      - 喩え
+      - 例え
+    expected: たとえ
+  - pattern: たのし
+    expected: 楽し
+  - pattern: 度々
+    expected: たびたび
+  - pattern: /溜ま([らりるれろっ])/
+    expected: たま$1
+  - pattern: 因みに
+    expected: ちなみに
+  - pattern: 丁度
+    expected: ちょうど
+  - pattern: 遂に
+    expected: ついに
+  - pattern: /掴([まみむめもん])/
+    expected: つか$1
+  - pattern: /繋([らりるれろっ])/
+    expected: つなが$1
+  - pattern: /繋([いがぎぐげご])/
+    expected: つな$1
+  - pattern: つねに
+    expected: 常に
+  - pattern: /つまづ([いかきくけこ])|躓([いかきくけこ])/
+    expected: つまず$1
+  - pattern: /辛([いかくけ])/
+    expected: つら$1
+  - pattern: /ずら([いかくけ])/
+    expected: づら$1
+  - pattern: んで([たなるろよ])
+    expected: んでい$1
+  - pattern: /ってな(?!く)/
+    expected: っていな
+    specs:
+      - from: わかってない
+        to:   わかっていない
+      - from: 言ってない
+        to:   言っていない
+      - from: 走ってない
+        to:   走っていない
+      - from: 持てない
+        to:   持てない
+      - from: 消えてなくなる
+        to:   消えてなくなる
+  - pattern: /([^捨当立])てる/
+    expected: $1ている
+  - pattern: /出来([かがのをは過す損ずなまるたれてそ])/
+    expected: でき$1
+  - pattern:
+      - 出来上
+      - 出来あ
+      - でき上
+    expected: できあ
+  - pattern:
+      - することが可能です
+      - することが可能になります
+    expected: できます
+  - pattern:
+      - することができ
+      - することが可能で
+    expected: でき
+  - pattern: するようになります
+    expected: します
+  - pattern: るようになります
+    expected: ます
+  - pattern: て欲し
+    expected: てほし
+  - pattern: で欲し
+    expected: でほし
+  - pattern: とうり
+    expected: とおり
+  - pattern: ときより
+    expected: 時折
+  - pattern: ときどき
+    expected: 時々
+  - pattern: とくに
+    expected: 特に
+  - pattern:
+      - 何処
+      - 何所
+    expected: どこ
+  - pattern: 途端
+    expected: とたん
+  - pattern: /(ピン)?留([まめ])/
+    regexpMustEmpty: $1
+    expected: とど$2
+    specs:
+      - from: ピン留め
+        to:   ピン留め
+      - from: 踏み留まる
+        to:   踏みとどまる
+  - pattern: /とは言え([^なまる])/
+    expected: とはいえ$1
+  - pattern: 共に
+    expected: ともに
+  - pattern: /捉え([ずなにぬまよらたてるろっ方中])/
+    expected: とらえ$1
+  - pattern: 囚わ
+    expected: とらわ
+  - pattern:
+      - 取りあえず
+      - 取り合えず
+      - 取り敢えず
+    expected: とりあえず
+  - pattern: /([^有])無([かくいけし])/
+    expected: $1な$2
+  - pattern: /尚([^早徳])/
+    expected: なお$1
+  - pattern:
+      - 名残
+      - 名残り
+    expected: なごり
+  - pattern: 何故
+    expected: なぜ
+  - pattern:
+      - 何某か
+      - 某か
+    expected: なにがしか
+  - pattern: /成り?済ま?([さしすせそ])|成り?すま([さしすせそ])/
+    expected: なりすま$1
+  - pattern: なので、
+    expected: ですので、
+  - pattern: 何となく
+    expected: なんとなく
+  - pattern: /に当た([っらりるれろ])/
+    expected: にあた$1
+  - pattern: /難([いく])/
+    expected: にく$1
+  - pattern: /の様([なにだで])/
+    expected: のよう$1
+  - pattern: /育([まみむめもん])/
+    expected: はぐく$1
+  - pattern: /([^手])筈/
+    expected: $1はず
+  - pattern: 甚だ
+    expected: はなはだ
+  - pattern: /孕([まみむめもんっ])/
+    expected: はら$1
+  - pattern:
+      - 遥か
+      - 遙か
+    expected: はるか
+  - pattern: 贔屓
+    expected: ひいき
+  - pattern: しいては
+    expected: ひいては
+  - pattern:
+      - 独り善がり
+      - 独りよがり
+    expected: ひとりよがり
+  - pattern: 一塊
+    expected: ひとかたまり
+  - pattern:
+      - 雛型
+      - 雛形
+      - ひな形
+      - ひながた
+    expected: ひな型
+  - pattern: /閃([かきくけこい])/
+    expected: ひらめ$1
+  - pattern: ふだん
+    expected: 普段
+  - pattern: 相応し
+    expected: ふさわし
+  - pattern:
+      - 付箋
+      - 付せん
+    expected: ふせん
+  - pattern: 殆ど
+    expected: ほとんど
+  - pattern: 正に
+    expected: まさに
+  - pattern:
+      - 益々
+      - 増々
+    expected: ますます
+  - pattern: 先ず
+    expected: まず
+  - pattern: /瞬([いかきくけこ])/
+    expected: またた$1
+  - pattern: 又は
+    expected: または
+  - pattern:
+      - 真っ新
+      - 真っさら
+    expected: まっさら
+  - pattern: 迄
+    expected: まで
+  - pattern: 纏ま
+    expected: まとま
+  - pattern: 纏め
+    expected: まとめ
+  - pattern: 稀
+    expected: まれ
+  - pattern: /剥([いかきくけこ])/
+    expected: む$1
+  - pattern: 寧ろ
+    expected: むしろ
+  - pattern: 滅多
+    expected: めった
+  - pattern:
+      - めんどくさ
+      - めんどうくさ
+      - 面倒臭
+      - めんど臭
+      - めんどう臭
+    expected: 面倒くさ
+  - pattern: めんどう
+    expected: 面倒
+  - pattern: 目論見
+    expected: もくろみ
+  - pattern: 勿論
+    expected: もちろん
+  - pattern: 勿体な
+    expected: もったいな
+#  - pattern: もっとも
+#    expected: 最も
+  - pattern: 尤も
+    expected: もっとも
+  - pattern: /貰([わいうえおっ])/
+    expected: もら$1
+  - pattern: 易し
+    expected: やさし
+  - pattern: 易々
+    expected: やすやす
+  - pattern: 厄介
+    expected: やっかい
+  - pattern: やっぱり
+    expected: やはり
+  - pattern: 闇雲
+    expected: やみくも
+  - pattern: 止め
+    expected: やめ
+  - pattern: やり取り
+    expected: やりとり
+  - pattern: 他所
+    expected: よそ
+  - pattern: /因([らりるれろっ])|依([らりるれろっ])/
+    expected: よ$1
+  - pattern: 僅か
+    expected: わずか
+# 「いいえ」にマッチしてしまった。厳しい気がするので一旦解除
+#  - pattern: いい
+#    expected: よい
+  - pattern: 心地よ
+    expected: 心地良
+  - pattern: /判([らりるれろっ])/
+    expected: わか$1
+  - pattern: /解([らりるれろっ])/
+    expected: わか$1
+  - pattern: /の分([^散割類解野離析岐])/
+    expected: のぶん$1
+  - pattern:
+      - 気をつか
+      - 気を使
+    expected: 気を遣
+  - pattern: 小さ目
+    expected: 小さめ
+  - pattern: 大き目
+    expected: 大きめ
+  - pattern: 少な目
+    expected: 少なめ
+  - pattern: /多目([^的])/
+    expected: 多め$1
+  - pattern: 低目
+    expected: 低め
+  - pattern: 高目
+    expected: 高め
+  - pattern: /([のる])かわり/
+    expected: $1代わり
+  - pattern: /代([らりるれろっ])/
+    expected: 代わ$1
+  - pattern: 全て
+    expected: すべて
+  - pattern: 全く
+    expected: まったく
+  - pattern: /([にも])関わらず|([にも])関らず|([にも])拘わらず|([にも])拘らず/
+    expected: $1かかわらず
+  - pattern: /埋めこ([まむめもん])|うめこ([まむめもん])/
+    expected: 埋め込$1
+  - pattern: /置き変([わえ])|置き代([わえ])|置き替([わえ])|置きか([わえ])/
+    expected: 置き換$1
+  - pattern: /書きこ([まみむめもん])|かきこ([まみむめもん])/
+    expected: 書き込$1
+  - pattern: /書き替([えわ])|書きか([えわ])|かきか([えわ])|書換([えわ])|書き変([えわ])/
+    expected: 書き換$1
+  - pattern: /読みこ([まみむめもん])|よみこ([まみむめもん])|読込([まみむめもん])/
+    expected: 読み込$1
+  - pattern: /読みか([えわ])|よみか([えわ])|読替([えわ])|読換([えわ])|読み換([えわ])/
+    expected: 読み替$1
+  - pattern: /きりか([えわ])|切り換([えわ])|切換([えわ])|切替([えわ])/
+    expected: 切り替$1
+  - pattern: /くみこ([まむめもん])|組込([まむめもん])|組みこ([まむめもん])/
+    expected: 組み込$1
+  - pattern: /くみこみ([^ま])|組み込み([^ま])|組みこみ([^ま])/
+    expected: 組込み$1
+  - pattern: /組合([わいうえおっ])|くみあ([わいうえおっ])/
+    expected: 組み合$1
+  - pattern: /組合([さしすせそっ])|くみあわ([さしすせそっ])/
+    expected: 組み合わ$1
+  - pattern: /くみか([わいうえおっ])|組替([わいうえおっ])/
+    expected: 組み替$1
+  - pattern: /ことな([りるれっ])/
+    expected: 異な$1
+  - pattern: /立ち合([わいうえおっ])|立ち遭([わいうえおっ])|立ち逢([わいうえおっ])/
+    expected: 立ち会$1
+  - pattern: /取りく([まみむめもん])|とりく([まみむめもん])|とり組([まみむめもん])/
+    expected: 取り組$1
+  - pattern: /取り変([わえ])|取り代([わえ])|取り換([わえ])|取りか([わえ])/
+    expected: 取り替$1
+  - pattern: /話し会([わいうえおっ])|話し遭([わいうえおっ])|話し逢([わいうえおっ])|話しあ([わいうえおっ])/
+    expected: 話し合$1
+  - pattern: /ひきつ([がぎぐげご])|引きつ([がぎぐげご])/
+    expected: 引き継$1
+  - pattern: /引き替([えわ])|引きか([えわ])|ひきか([えわ])|引換([えわ])|引き変([えわ])/
+    expected: 引き換$1
+  - pattern: /目が会([わいうえおっ])|目が遭([わいうえおっ])|目が逢([わいうえおっ])|目があ([わいうえおっ])/
+    expected: 目が合$1
+  - pattern:
+      - よびだ
+      - 呼びだ
+      - 呼出
+    expected: 呼び出
+  - pattern: 作りだ
+    expected: 作り出
+  - pattern: 読みだ
+    expected: 読み出
+  - pattern: 貼りだ
+    expected: 貼り出
+  - pattern: 取りだ
+    expected: 取り出
+  - pattern:
+      - とりあげ
+      - 取りあげ
+    expected: 取り上げ
+  - pattern: /とりこ([まみむめもん])|取りこ([まみむめもん])|とり込([まみむめもん])/
+    expected: 取り込$1
+  - pattern: 作りあ
+    expected: 作り上
+  - pattern:
+      - からみあ
+      - からみ合
+      - 絡みあ
+    expected: 絡み合
+  - pattern: からっぽ
+    expected: 空っぽ
+  - pattern: 売上げ
+    expected: 売り上げ
+  - pattern:
+      - 巡り会
+      - 巡り遭
+      - 巡り逢
+    expected: 巡り合
+  - pattern: 割込み
+    expected: 割り込み
+  - pattern: 割当
+    expected: 割り当て
+  - pattern: 割切り
+    expected: 割り切り
+  - pattern:
+      - しめくく
+      - 締め括
+    expected: 締めくく
+  - pattern: 使いなれ
+    expected: 使い慣れ
+  - pattern:
+      - 使いわけ
+      - つかいわけ
+    expected: 使い分け
+  - pattern: 落としこ
+    expected: 落とし込
+  - pattern: 切りわけ
+    expected: 切り分け
+  - pattern:
+      - 間に会
+      - 間に遭
+      - 間に逢
+    expected: 間に合
+  - pattern:
+      - 災難に合
+      - 災難に会
+      - 災難に逢
+    expected: 災難に遭
+  - pattern:
+      - 事故に合
+      - 事故に会
+      - 事故に逢
+    expected: 事故に遭
+  - pattern:
+      - 気が会
+      - 気が遭
+      - 気が逢
+    expected: 気が合$1
+  - pattern:
+      - 落ち会
+      - 落ち遭
+      - 落ち逢
+    expected: 落ち合
+  - pattern: /ふるま([わいうえおっ])|振舞([わいうえおっ])|振るま([わいうえおっ])/
+    expected: 振る舞$1
+  - pattern: /みはから([いうえっ])/
+    expected: 見計ら$1
+  - pattern: みえ
+    expected: 見え
+  - pattern: みあた
+    expected: 見当た
+  - pattern:
+      - いいわけ
+      - 言訳
+      - 言いわけ
+    expected: 言い訳
+  - pattern: いえない
+    expected: 言えない
+  - pattern: いえなく
+    expected: 言えなく
+  - pattern: いえる
+    expected: 言える
+  - pattern: いわれる
+    expected: 言われる
+  - pattern:
+      - 未だ
+      - 今だ
+    expected: いまだ
+  - pattern:
+      - 今ひとつ
+      - 今一つ
+      - いま一つ
+    expected: いまひとつ
+  - pattern:
+      - 今更
+      - 今さら
+    expected: いまさら
+  - pattern: 今頃
+    expected: 今ごろ
+  - pattern: /([^な])いままで/
+    expected: $1今まで
+  - pattern: 今時
+    expected: 今どき
+  - pattern: 今更
+    expected: 今さら
+  - pattern: 尚更
+    expected: なおさら
+  - pattern: 更なる
+    expected: さらなる
+  - pattern: /([^変])更に/
+    expected: $1さらに
+  - pattern: やむをえ|止むを得
+    expected: やむを得
+  - pattern: すこし
+    expected: 少し
+  - pattern: /すくな(?!り|る)/
+    expected: 少な
+    specs:
+      - from: すくなく
+        to:   少なく
+      - from: わかりやすくなり
+        to:   わかりやすくなり
+  - pattern: 少い
+    expected: 少ない
+  - pattern: おこし
+    expected: 起こし
+  - pattern: おこす
+    expected: 起こす
+  - pattern: 何げな
+    expected: 何気な
+  - pattern: なにか
+    expected: 何か
+  - pattern: なにしろ
+    expected: 何しろ
+  - pattern:
+      - なにとそ
+      - なにとぞ
+      - 何卒
+    expected: 何とぞ
+  - pattern: なんど
+    expected: 何度
+  - pattern: なんら
+    expected: 何ら
+  - pattern: なんの
+    expected: 何の
+  - pattern: 生れ
+    expected: 生まれ
+  - pattern: それ故
+    expected: それゆえ
+  - pattern: /([^事])故に/
+    expected: $1ゆえに
+  - pattern: 程々
+    expected: ほどほど
+  - pattern: これ程
+    expected: これほど
+  - pattern: それ程
+    expected: それほど
+  - pattern: あれ程
+    expected: あれほど
+  - pattern: どれ程
+    expected: どれほど
+  - pattern: なる程
+    expected: なるほど
+  - pattern: さきほど|先程
+    expected: 先ほど
+#  - pattern: /基([いかきくけこ])|基ず([いかきくけこ])|もとず([いかきくけこ])|もとづ([いかきくけこ])/
+#    expected: 基づ$1
+#  - pattern:
+#      - 元々
+#      - 本々
+#    expected: もともと
+  - pattern: /基([^数準盤板底礎本])/
+    expected: もと$1
+  - pattern: /([^追])及び/
+    expected: $1および
+  - pattern: したうえ
+    expected: した上
+  - pattern: そのうえ
+    expected: その上
+  - pattern: かたまり
+    expected: 塊
+  - pattern: やりかた
+    expected: やり方
+  - pattern: ありかた
+    expected: あり方
+  - pattern: かたち
+    expected: 形
+  - pattern: かた
+    expected: 方
+  - pattern: 済まな
+    expected: すまな
+  - pattern: 済みません
+    expected: すみません
+  - pattern: あたりまえ
+    expected: 当たり前
+  - pattern: /汚な([かくいけ])/
+    expected: 汚$1
+  - pattern: /果([さしすせそ])/
+    expected: 果た$1
+#  - pattern: /([^排人])他([^ァ-ヶ社者人方])/
+#    expected: $1ほか$2
+  - pattern: 後ほど
+    expected: のちほど
+  - pattern: うしろ
+    expected: 後ろ
+  - pattern:
+      - 頭が堅
+      - 頭が硬
+    expected: 頭が固
+  - pattern: あつめ
+    expected: 集め
+  - pattern: /あては([まめ])/
+    expected: 当ては$1
+  - pattern: 意志決定
+    expected: 意思決定
+  - pattern: 威大
+    expected: 偉大
+  - pattern: いっそう
+    expected: 一層
+  - pattern: おおまか
+    expected: 大まか
+  - pattern: あふれ
+    expected: 溢れ
+  - pattern: 窺え
+    expected: うかがえ
+  - pattern:
+      - 窺い知
+      - 伺い知
+    expected: うかがい知
+  - pattern: /失な([わいうえおっ])/
+    expected: 失$1
+  - pattern: /おお([かいくけこ])/
+    expected: 多$1
+  - pattern: そって
+    expected: 沿って
+  - pattern: /押え([なたまれる])/
+    expected: 押さえ$1
+  - pattern: 押し進め
+    expected: 推し進め
+  - pattern: /折返([さしすせそ])/
+    expected: 折り返$1
+  - pattern: /加([らりるれろっ])/
+    expected: 加わ$1
+  - pattern: 静的型付け言語
+    expected: 静的型付き言語
+  - pattern: 動的型付け言語
+    expected: 動的型付き言語
+  - pattern: 変わり映え
+    expected: 代わり映え
+  - pattern: 狗肉の策
+    expected: 苦肉の策
+  - pattern: /こわれ([たちつてとらりるれろっ])/
+    expected: 壊れ$1
+  - pattern: 混み入っ
+    expected: 込み入っ
+  - pattern: /怪([いまみむめも])/
+    expected: 怪し$1
+  - pattern: おのおの
+    expected: 各々
+  - pattern: 最新の注意
+    expected: 細心の注意
+  - pattern: 列志向
+    expected: 列指向
+  - pattern: 行志向
+    expected: 行指向
+  - pattern: オブジェクト志向
+    expected: オブジェクト指向
+  - pattern: ドキュメント志向
+    expected: ドキュメント指向
+  - pattern: アスペクト志向
+    expected: アスペクト指向
+  - pattern: 粗結合
+    expected: 疎結合
+  - pattern: 確かに
+    expected: たしかに
+  - pattern: /たしか([^に])/
+    expected: 確か
+  - pattern: /確め([たなまれる])/
+    expected: 確かめ$1
+  - pattern: /かっこ([^良悪いイ])|カッコ([^良悪いイ])/
+    expected: 括弧$1
+  - pattern: かんたん
+    expected: 簡単
+  - pattern: 業社
+    expected: 業者
+  - pattern: /陥([たなま])/
+    expected: 陥れ$1
+  - pattern: 危い
+    expected: 危ない
+  - pattern: /喜し([かくいけ])/
+    expected: 喜ばし$1
+  - pattern: /起([さしすせそらりるれろっ])/
+    expected: 起こ$1
+  - pattern: /輝し([かくいけ])/
+    expected: 輝かし$1
+  - pattern: /恐し([かくいけ])/
+    expected: 恐ろし$1
+  - pattern: 近頃
+    expected: 近ごろ
+  - pattern: /隣合([わいうえおっ])/
+    expected: 隣り合$1
+  - pattern:
+      - 決っ
+      - きまっ
+    expected: 決まっ
+  - pattern:
+      - 現われ
+      - あらわれ
+    expected: 現れ
+  - pattern: /かぎ([らりるれろっ])/
+    expected: 限$1
+  - pattern: /語([わいうえお])/
+    expected: 語ら$1
+  - pattern: /交([らりるれろっ])/
+    expected: 交わ$1
+  - pattern: /行な([わいうえおっ])|おこな([わいうえおっ])/
+    expected: 行$1
+  - pattern: あわて
+    expected: 慌
+  - pattern: あわ
+    expected: 合わ
+  - pattern: /混([らりるれろっ])/
+    expected: 混ざ$1
+  - pattern: おも([いうわ])
+    expected: 思$1
+  - pattern: 差違
+    expected: 差異
+  - pattern:
+      - プレフィックス
+      - プレフィクス
+      - プリフィックス
+    expected: 接頭辞
+  - pattern:
+      - サフィックス
+      - サフィックス
+      - サフィクス
+    expected: 接尾辞
+  - pattern: 事前準備
+    expected: 下準備
+  - pattern: 前準備
+    expected: 下準備
+  - pattern: 誌幅
+    expected: 紙幅
+  - pattern: 紙面
+    expected: 誌面
+  - pattern: /賜わ([らりるれろっ])/
+    expected: 賜$1
+  - pattern: しだいに
+    expected: 次第に
+  - pattern: /すて([たちつてとらりるれろっ])/
+    expected: 捨て$1
+  - pattern: 成功を納め
+    expected: 成功を収め
+  - pattern: /おわ([らりるれろっ][^か])/
+    expected: 終わ$1
+  - pattern: /終([らりるれろっ])/
+    expected: 終わ$1
+  - pattern: /集([らりるれろっ])/
+    expected: 集ま$1
+  - pattern: 充分
+    expected: 十分
+  - pattern: したがう
+    expected: 従う
+  - pattern: とりま
+    expected: 取り巻
+  - pattern: とうてい
+    expected: 到底
+  - pattern: /柔か([だない])/
+    expected: 柔らか$1
+  - pattern: /重([ずじ])/
+    expected: 重ん$1
+  - pattern: /畳込([まみむめも])/
+    expected: 畳み込$1
+  - pattern: 定形的
+    expected: 定型的
+  - pattern:
+      - 出合
+      - 出遭
+      - 出逢
+    expected: 出会
+  - pattern:
+      - できごと
+      - でき事
+      - 出来ごと
+    expected: 出来事
+  - pattern: 適正
+    expected: 適性
+  - pattern: /助([たなまれる])/
+    expected: 助け$1
+  - pattern:
+      - 問合せ
+      - 問い合せ
+      - 問合わせ
+      - 問いあわせ
+      - といあわせ
+    expected: 問い合わせ
+  - pattern: /承わ([らりるれろっ])/
+    expected: 承$1
+  - pattern: ご紹介
+    expected: 紹介
+  - pattern: 晴やか
+    expected: 晴れやか
+  - pattern: /清か([だな])/
+    expected: 清らか$1
+  - pattern: おいたち
+    expected: 生い立ち
+  - pattern: /積([らりるれろっ])/
+    expected: 積も$1
+  - pattern: ご説明
+    expected: 説明
+  - pattern: 憎しい
+    expected: 憎らしい
+  - pattern: /つづ([^つ])/
+    expected: 続$1
+  - pattern:
+      - 取って変
+      - 取って換
+      - 取って替
+    expected: 取って代
+  - pattern:
+      - 存知
+      - ぞんじ
+    expected: 存じ
+  - pattern: だれ
+    expected: 誰
+  - pattern: /断わ([らりるれろっ])/
+    expected: 断$1
+  - pattern: 内臓
+    expected: 内蔵
+  - pattern: /なか([かでに])/
+    expected: 中$1
+  - pattern: /なら(ば(?!、)|[びぶべぼん])/
+    expected: 並$1
+    specs:
+      - from: ならびに
+        to:   並びに
+      - from: ならば、
+        to:   ならば、
+  - pattern: /著わ([さしすせそ])/
+    expected: 著$1
+  - pattern: 著い
+    expected: 著しい
+  - pattern:
+      - 手に追えな
+      - てに追えな
+      - てに負えな
+      - てにおえな
+      - 手におえな
+    expected: 手に負えな
+  - pattern: /定([らりるれろっ])/
+    expected: 定ま$1
+  - pattern: /当([らりるれろっ])/
+    expected: 当た$1
+  - pattern:
+      - 踏え
+      - ふまえ
+    expected: 踏まえ
+  - pattern: /おなじ([^み])/
+    expected: 同じ$1
+  - pattern: なじみ
+    expected: 馴染み
+  - pattern:
+      - 引きづ
+      - ひきづ
+    expected: 引きず
+  - pattern: むずかしい
+    expected: 難しい
+  - pattern: /まか([さしすせそ])/
+    expected: 任$1
+  - pattern: /([^っ])伴な|([^っ])ともな/
+    expected: $1伴
+  - pattern: /悲([まみむめも])/
+    expected: 悲し$1
+  - pattern:
+      - 較べ
+      - くらべ
+    expected: 比べ
+  - pattern:
+      - かならず
+      - 必らず
+    expected: 必ず
+  - pattern: /表わ([さしすせそ])|あらわ([さしすせそ])/
+    expected: 表$1
+  - pattern: /浮([ばびぶべぼん])/
+    expected: 浮か$1
+  - pattern: /わかれ([^ば])/
+    expected: 分かれ$1
+  - pattern: /わけ([らるれろてよ、])/
+    expected: 分け$1
+  - pattern: /聞え([なたまれる])/
+    expected: 聞こえ$1
+  - pattern: /変([らりるれろっ])/
+    expected: 変わ$1
+  - pattern: /捕え([なたまれる])/
+    expected: 捕らえ$1
+  - pattern: /暮([さしすせそ])/
+    expected: 暮ら$1
+  - pattern: /([^鮮])明か/
+    expected: $1明らか
+  - pattern: もどって
+    expected: 戻って
+  - pattern:
+      - 返り値
+      - 返値
+    expected: 戻り値
+  - pattern: /勇し([かくい])/
+    expected: 勇まし$1
+  - pattern: /揺([がぎぐげご])/
+    expected: 揺ら$1
+  - pattern: /頼し([かくい])/
+    expected: 頼もし$1
+  - pattern: /冷([さしすせそ])/
+    expected: 冷や$1
+  - pattern: /連([らりるれろっ])|つらな([らりるれろっ])/
+    expected: 連な$1
+  - pattern: はさまざま
+    expected: はさまざま
+  - pattern: /はさ([まみむめもん])/
+    expected: 挟$1
+  - pattern: おそれ
+    expected: 恐れ
+  - pattern: /([^っ])さきに/
+    expected: $1先に
+  - pattern: 自分自信
+    expected: 自分自身
+  - pattern: /満([さしすせそっ])|みた([さしすせそっ])/
+    expected: 満た$1
+  - pattern: /([をがに])生か/
+    expected: $1活か
+  - pattern: /いとな([まみむめも])/
+    expected: 営$1
+  - pattern: /かかげ([たてらる])/
+    expected: 掲げ$1
+  - pattern: /がた([ちつっ])/
+    expected: が経$1
+  - pattern: /うめ([たつて])/
+    expected: 埋め$1
+  - pattern:
+      - お勧め
+      - お薦め
+      - お奨め
+      - オススメ
+    expected: おすすめ
+  - pattern:
+      - てがけ
+      - 手掛け
+    expected: 手がけ
+  - pattern: みずから
+    expected: 自ら
+  - pattern: /いた([るれろ])/
+    expected: 至$1
+  - pattern: そなえ
+    expected: 備え
+  - pattern: /まね([いかきくけこ])/
+    expected: 招$1
+  - pattern: 子供
+    expected: 子ども
+  - pattern: 塔載
+    expected: 搭載
+  - pattern: 一番最初
+    expected: 一番初め
+  - pattern: 貼付け
+    expected: 貼り付け
+  - pattern: 必用
+    expected: 必要
+  - pattern: /あたえ([たつてらりるれろっ])/
+    expected: 与え$1
+  - pattern: /すす([まみむめもん])/
+    expected: 進$1
+  - pattern: 焦点をあて
+    expected: 焦点を当て
+  - pattern: /おも([いうえおわっ])/
+    expected: 思$1
+  - pattern: /おも([なにとだで])/
+    expected: 主$1
+  - pattern: 高値の花
+    expected: 高嶺の花
+  - pattern: たいする
+    expected: 対する
+  - pattern: たいし
+    expected: 対し
+  - pattern:
+      - たずさわ
+      - たづさわ
+    expected: 携わ
+  - pattern: 訪ず
+    expected: 訪
+  - pattern: 短か
+    expected: 短
+  - pattern: わたし
+    expected: 私
+  - pattern: /くわし([いく])/
+    expected: 詳し$1
+  - pattern: 陽の目
+    expected: 日の目
+  - pattern: 保障
+    expected: 保証
+  - pattern: 移譲
+    expected: 委譲
+  - pattern: 稼動
+    expected: 稼働
+  - pattern: 芋蔓
+    expected: 芋づる
+  - pattern: あいだ
+    expected: 間
+  - pattern: /しめ([さしすせそ])/
+    expected: 示$1
+  - pattern: /のべ([^たてなるまよ、])/
+    expected: 延べ$1
+  - pattern: /あつま([らりるれろ])/
+    expected: 集ま$1
+  - pattern: /あきらめ([たてなるまよ、])/
+    expected: 諦め$1
+  - pattern: 成立ち
+    expected: 成り立ち
+  - pattern:
+      - たどりつ
+      - 辿り着
+      - 辿りつ
+    expected: たどり着
+  - pattern: 安定板
+    expected: 安定版
+  - pattern: /かえ([さしすせそっ])/
+    expected: 返$1
+  - pattern: /さが([さしすせそっ])/
+    expected: 探$1
+  - pattern: 見様見真似
+    expected: 見よう見まね
+  - pattern: 買物
+    expected: 買い物
+  - pattern: /ほどこ([さしすせそ])/
+    expected: 施$1
+  - pattern: /使いき([らりるれろっ])/
+    expected: 使い切$1
+  - pattern: /逃が([さしすせそれ])/
+    expected: 逃$1
+  - pattern: /濡れ手[でに][泡粟]/
+    expected: 濡れ手で粟
+  - pattern: /もど([^ち])/
+    expected: 戻$1
+  - pattern: 携帯キャリア
+    expected: 携帯電話キャリア
+  - pattern:
+      - 代金引き換え
+      - 代引
+      - 代引き
+    expected: 代金引換
+  - pattern: /割引(?:き)?/
+    expected: 割り引き
+  - pattern:
+      - ひとめ
+      - ひと目
+    expected: 一目
+  - pattern: 復号化
+    expected: 復号
+  - pattern: 手間取
+    expected: 手間ど
+  - pattern: 中味
+    expected: 中身
+  - pattern: /則([らりるれろっ])/
+    expected: のっと$1
+  - pattern: 洗錬
+    expected: 洗練
+  - pattern: 基板
+    expected: 基盤
+  - pattern: ふれ
+    expected: 触れ
+  - pattern: /あお([がぎぐげごっ])/
+    expected: 仰$1
+  - pattern:
+      - 独り事
+      - ひとり事
+      - ひとりごと
+    expected: 独り言
+  - pattern: 本校
+    expected: 本稿
+  - pattern: /つぎ([にの])/
+    expected: 次$1
+  - pattern: 見きれ
+    expected: 見切れ
+  - pattern: /見做([さしすせそ])/
+    expected: みな$1
+  - pattern: 無駄使い
+    expected: 無駄遣い
+  - pattern: 肩をなでおろ
+    expected: 胸をなでおろ
+  - pattern: /陥い([らりるれろっ])|おちい([らりるれろっ])/
+    expected: 陥$1
+  - pattern: /かさ([なね])/
+    expected: 重$1
+  - pattern: 情報原
+    expected: 情報源
+  - pattern: 過度期
+    expected: 過渡期
+  - pattern: 流れを組
+    expected: 流れをく
+  - expected: 無駄遣い
+    pattern:
+      - 無駄使い
+      - ムダ遣い
+      - ムダ使い
+      - 無駄づかい
+      - 無駄ずかいい
+      - ムダづかい
+      - ムダずかい
+  - expected: Cookie
+    pattern:  クッキー
+  - expected: Cookie
+  - expected: WebSocket
+    pattern:  /\bWeb Socket\b/
+  - expected: $1Web$2
+    pattern:  /(?:([^/])ウェブ)|(?:ウェブ([^/\+]))/
+  - expected: $1Web$2
+    pattern:  /(?:([^/])ウェッブ)|(?:ウェッブ([^/\+]))/
+  - expected: O/Rマッ
+    pattern:  /ORマッ|O-Rマッ/
+  - expected: O/Rマッパ
+    pattern:  /O\/Rマッパー|\bORM\b/
+  - expected: アイデア
+    pattern:  /アィディア|アイディア|アィディア|アィデア/
+  - expected: アスタリスク
+    pattern:  /アステリスク/
+  - expected: アーキテクチャー
+    pattern:  /アーキテクチャ|アーキティクチャ/
+  - expected: アクティビティ
+    pattern:  /\bActivity\b|アクティビティー/
+  - expected: アダプタ
+    pattern:  /アダプター/
+  - expected: アップローダー
+    pattern:  /アップローダ(?!ー)/
+  - expected: アドバイス
+    pattern:  /アドヴァイス/
+  - expected: アノテーション
+    pattern:  /アノーテーション/
+  - expected: アプレット
+    pattern:  /\bApplet\b/
+  - expected: アンダースコア
+    pattern:  /アンダーバー/
+  - expected: イシュア
+    pattern:  /イシュアー/
+  - expected: イディオム
+    pattern:  /イデオム/
+  - expected: インジケータ
+    pattern:  /インジケーター|インジゲーター|インジゲータ/
+  - expected: インスタンス
+    pattern:  /インスンタンス/
+  - expected: インストーラ
+    pattern:  /インストーラー/
+  - expected: インスパイア
+    pattern:  /インスパイヤ/
+  - expected: インスペクタ
+    pattern:  /インスペクター/
+  - expected: インタフェイス
+    pattern:  /インタフェイス|インターフェース|インターフェース|インターフェィス/
+  - expected: インタプリタ
+    pattern:  /インタープリタ|インタプリター|インタープリター/
+  - expected: インデックス
+    pattern:  /インデクス/
+  - expected: インテント
+    pattern:  /\bIntent\b/
+  - expected: ウィジェット
+    pattern:  /\bWidget\b|\bwidget\b/
+  - expected: ウィルス
+    pattern:  /ウイルス/
+  - expected: ウィンドウ
+    pattern:  /ウインドウ/
+  - expected: ウェア
+    pattern:  ウエア
+    spec:
+      - from: ハードウエア
+        to:   ハードウェア
+  - expected: エディター
+    pattern:  /エディタ(?!ー)/
+  - expected: エミッタ
+    pattern:  /エミッター/
+  - expected: エンコーダ
+    pattern:  /エンコーダー/
+  - expected: デコーダ
+    pattern:  /デコーダー/
+  - expected: エミュレータ
+    pattern:  /エミュレーター/
+  - expected: エンティティ
+    pattern:
+      - エンティティー
+  - expected: エントリ
+    pattern:  /エントリー/
+  - expected: オブザーバ
+    pattern:  /オブザーバー|オブサーバー|オブサーバ/
+  - expected: オプション
+    pattern:  /オブション/
+  - expected: オン／オフ
+    pattern:  /ON\/OFF|ON／OFF|オン・オフ|オン\/オフ/
+  - expected: カウンタ
+    pattern:  /カウンター/
+  - expected: カバレッジ
+    pattern:  /カバリッジ|カバレージ/
+  - expected: ガベージ
+    pattern:  /ガベージ・|ガーベジ|ガーベジ・|ガーベージ|ガーベージ・|ガーベッジ|ガーベッジ・|ガベッジ/
+  - expected: カテゴリー
+    pattern:  /カテゴリ(?!ー)/
+  - expected: カラムナ
+    pattern:  /カラムナー/
+  - expected: カンマ
+    pattern:  /コンマ/
+  - expected: キャラクタ
+    pattern:  /キャラクター/
+  - expected: キャッシュ
+    pattern:
+      - /cache(?![^a-zA-Z\-])/
+      - /Cache(?![^a-zA-Z\-])/
+  - expected: 近隣地域
+    pattern:
+      - /ローカルエリア/
+      - /ローカル地域/
+  - expected: クエリー文字列
+    pattern:
+      - QueryString
+      - Query String
+      - クエリストリング
+      - クエリ文字列
+      - クエリーストリング
+  - expected: クエリー$1
+    pattern:  /クエリ(?!ー)/
+  - expected: クオート
+    pattern:  /クォート|クオーテーション|クォーテーション/
+  - expected: クオリティ
+    pattern:  /クオリティー|クォリティ|クォリティー/
+  - expected: クラスタ
+    pattern:  /クラスター/
+  - expected: グラウンド
+    pattern:  /グランド/
+  - expected: グリッド
+    pattern:  /\bGrid\b/
+  - expected: クロージャ
+    pattern:  /クロージャー/
+  - expected: クローラ
+    pattern:  /クローラー/
+  - expected: ゲッタ
+    pattern:  /ゲッター/
+  - expected: コピー & ペースト
+    pattern:
+      - コピー＆ペースト
+      - コピペ
+      - コピーアンドペースト
+      - コピーペースト
+  - expected: コミュニ
+    pattern:  /コミニュ/
+  - expected: アンコメント
+    pattern:  /コメントイン/
+  - expected: コンストラクタ
+    pattern:  /コンストラクター/
+  - expected: コンテキスト
+    pattern:  /コンテクスト/
+  - expected: コンテンツ
+    pattern:  /コンテント/
+  - expected: コンテンツプロバイダ
+    pattern:  /\bContent provider\b/
+  - expected: コンテナ
+    pattern:  /コンテナー/
+  - expected: コンピューター
+    pattern:  /コンピュータ/
+  - expected: コンポーネント
+    pattern:  /コンポネント/
+  - expected: コントローラ
+    pattern:  /コントローラー/
+  - expected: サーバー
+    pattern:  /サーバ(?!ー)/
+  - expected: シェア
+    pattern:  /シェア率/
+  - expected: ジェスチャ
+    pattern:  /ジェスチャー/
+  - expected: ジェネレータ
+    pattern:  /ジェネレーター/
+  - expected: ジェネレーティブ
+    pattern:  /ジェネレイティブ/
+  - expected: ジオタグ
+    pattern:  /\bGeotag\b|\bgeotag\b/
+  - expected: シグネチャ
+    pattern:  /シグネチャー/
+  - expected: シミュレー
+    pattern:  /シュミレー/
+  - expected: シンクロナイザ
+    pattern:  /シンクロナイザー/
+  - expected: スカラ
+    pattern:  /スカラー/
+  - expected: スクラム
+    pattern:  /\bScrum\b/
+  - expected: スタンドアローン
+    pattern:  /スタンドアロン/
+  - expected: ストアド
+    pattern:  /ストアード/
+  - expected: ストレージ
+    pattern:  /ストレッジ|ストレジ/
+  - expected: スマートフォン
+    pattern:  /スマフォ|スマホ/
+  - expected: スムーズ
+    pattern:  /スムース/
+  - expected: セキュリティ
+    pattern:  /セキュリティー/
+  - expected: セッション
+    pattern:  /\bsession\b|\bSession\b/
+  - expected: セレクタ
+    pattern:  /セレクター/
+  - expected: ソフトウェア
+    pattern: /ソフトウエア/
+  - expected: ダイアグラム
+    pattern:  /ダイヤグラム/
+  - expected: タイムスタンプ
+    pattern:
+      - timestamp
+      - Timestamp
+  - expected: ツイート
+    pattern:
+      - tweet
+      - Tweet
+      - ツィート
+# 日本語で書くこともあるので要らないかも？
+#  - expected: テーブル
+#    pattern:
+#      - table
+#      - Table
+  - expected: 地域コミュニティ
+    pattern:  /\blocal community\b/i|/ローカルコミュニティ/
+  - expected: チャプタープログラム
+    pattern:  /\bchapter program\b/i|/ローカルコミュニティ/
+  - expected: データサービス
+    pattern:  /\bData Services\b/
+  - expected: データ
+    pattern:  /データー/
+  - expected: センター
+    pattern:  /センタ([^ー])/
+  - expected: データ同期
+    pattern:  /\bData Sync\b/
+  - expected: ディザスタリカバリ
+    pattern:  /ディザスタ・リカバリ/
+  - expected: ディスク
+    pattern:  /\bDisk\b/
+  - expected: ディスパッチャ
+    pattern:  /ディスパッチャー/
+  - expected: ディスプレイ
+    pattern:  /ディスプレー/
+  - expected: ディレクトリ
+    pattern:  /ディレクトリー/
+  - expected: テクノロジ
+    pattern:  /テクノロジー/
+  - expected: デジタルカメラ
+    pattern:  /デジカメ/
+  - expected: デバッグ
+    pattern:  /デバック/
+  - expected: デバッガ
+    pattern:  /デバッガー/
+  - expected: デフォルト
+    pattern:  /既定|ディフォルト|デフォールト/
+  - expected: デプロイ
+    pattern:  /デプロイメント/
+  - expected: デリバリ
+    pattern:  /デリバリー/
+  - expected: ドライバ
+    pattern:  /ドライバー/
+  - expected: ドラッグ & ドロップ
+    pattern:  /ドラッグ・アンド・ドロップ|ドラッグアンドドロップ|ドラッグ＆ドロップ|ドラッグ & ドロップ/
+  - expected: トリガー
+    pattern:  /トリガ(?!ー)/
+  - expected: バイナリ
+    pattern:  /バイナリー/
+  - expected: ハイパーリンク
+    pattern:  /ハイパー・リンク/
+  - expected: パーサー
+    pattern:  /パーサ(?!ー)|パーザー|パーザ/
+  - expected: パーマリンク
+    pattern:  /\bPermalink\b|\bpermalink\b|\bpermanent link\b|パーマネントリンク/
+  - expected: バッファ
+    pattern:  /バッファー/
+  - expected: パス
+    pattern:  /\bpath\b|\bPath\b/
+  - expected: パターン
+    pattern:  /パタン/
+  - expected: ハッシュ
+    pattern:  /\bhash\b|\bHash\b/
+  - expected: バラ
+    pattern:  /薔薇/
+  - expected: バラエティ
+    pattern:  /バラエティー/
+  - expected: パラメータ
+    pattern:  /パラメタ|パラメーター/
+  - expected: ハンドラ
+    pattern:  /ハンドラー/
+  - expected: ビューア
+    pattern:  /ビューアー|ビューワー|ビューワ/
+  - expected: ビルダ
+    pattern:  /ビルダー/
+  - expected: ビルトイン
+    pattern:  /ビルドイン/
+  - expected: ヒット率
+    pattern:  /hit率/
+  - expected: ファイラ
+    pattern:  /ファイラー/
+  - expected: ファクトリ
+    pattern:  /ファクトリー/
+  - expected: フィーチャーフォン
+    pattern:  /フィーチャフォン/
+  - expected: フォルダー
+    pattern:  /フォルダ(?!ー)/
+  - expected: ブラウザー
+    pattern:
+      - /Webブラウザー?/
+      - /WEBブラウザー?/
+      - /ブラウザー(?!ー)/
+  - expected: プライマリ
+    pattern:  /プライマリー/
+  - expected: プラットフォーム
+    pattern:  /プラットホーム/
+  - expected: ブレーク
+    pattern:  /ブレイク/
+  - expected: プレーン
+    pattern:  プレイン(?!グ)
+    specs:
+      - from: プレイング
+        to:   プレイング
+  - expected: ブローカ$1
+    pattern:  /ブローカー([^ー])/
+  - expected: プロパティ
+    pattern:  /プロパティー/
+  - expected: ヘビー
+    pattern:  /ヘヴィ/
+  - expected: ファイアウォール
+    pattern:  /ファイアーウォール|ファイヤーウォール|ファイヤウォール|ファイヤーウオール/
+  - expected: ファイバチャネル
+    pattern:  /ファイバチャンネル|ファイバチャネル|ファイバーチャンネル/
+  - expected: フィルター
+    pattern:  /フィルタ(?!ー)/
+  - expected: フィクスチャ
+    pattern:  /フィクスチャー/
+  - expected: フェイルオーバー
+    pattern:  /フェイルオーバ(?!ー)|フェールオーバー|フェールオーバ(?!ー)/
+  - expected: フェーズ
+    pattern:  /フェイズ/
+  - expected: フッター
+    pattern:  /フッタ(?!ー)|フッダ/
+  - expected: プロキシ
+    pattern:  /プロクシ|プロクシー|プロキシー|\bProxy\b|\bproxy\b/
+  - expected: ブログ
+    pattern: /(?![^/])(?:blog|Blog)(?![^/])/
+    specs:
+      - from: http://blog.example.com/
+        to:   http://blog.example.com/
+      - from: http://example.com/foo-blog/
+        to:   http://example.com/foo-blog/
+  - expected: プロシージャ
+    pattern:  /プロシージャー/
+  - expected: プロバイダ
+    pattern:  /プロバイダー/
+  - expected: ベンダー
+    pattern:  /ベンダ(?!ー)/
+  - expected: ヘッダー
+    pattern:  /ヘッダ(?!ー)|ヘッタ|ヘッター/
+  - expected: ベクター
+    pattern:  /ベクタ(?!ー)/
+  - expected: ページャ
+    pattern:  /ページャー/
+  - expected: ポインタ
+    pattern:  /ポインター/
+  - expected: ポッドキャスト
+    pattern:  /\bPodCast\b|\bpodcast\b|\bPodcast\b/
+  - expected: $1マイクロ秒
+    pattern:  /([0-9])μs/
+  - expected: $1ミリ秒
+    pattern:  /([0-9])\bms\b/
+  - expected: マトリックス
+    pattern:  /マトリクス/
+  - expected: マネジメント
+    pattern:  /マネージメント/
+  - expected: メーカー
+    pattern:  /メーカ(?!ー)/
+  - expected: メーリングリスト
+    pattern:  /\bML\b(?!系)/
+    specs:
+      - from: SML#
+        to:   SML#
+      - from: ML系言語
+        to:   ML系言語
+      - from: MLなど
+        to:   メーリングリストなど
+  - expected: メタファ
+    pattern:  /メタファー/
+  - expected: メモリ
+    pattern:  /メモリー/
+  - expected: メンテナンス
+    pattern:  /メインテナンス/
+  - expected: メンテナンス$1
+    pattern:  /メンテ([^ナ])/
+  - expected: モジュール
+    pattern:  /\bmodule\b|\bModule\b/
+  - expected: レジューム
+    pattern:  /リジューム/
+  - expected: ユーティリティ
+    pattern:  /ユーティリティー/
+  - expected: ユニットテスト
+    pattern:
+      - Unitテスト
+      # 単体テストはケースバイケース
+      - 単体テスト
+  - expected: ライブラリ
+    pattern:  /ライブラリー/
+  - expected: リガチャ
+    pattern:  /リガチャー/
+  - expected: リグレッション
+    pattern:
+      - デグレード
+      # デグレは英語圏では使わない by Jenkins川口さん
+      - デグレ
+  - expected: リスナ
+    pattern:  /リスナー/
+  - expected: リバースプロキシ
+    pattern:  /\bReverse Proxy\b/
+  - expected: リファラー
+    pattern:  /リファラ/
+  - expected: リポジトリ
+    pattern:  /リポジトリー|レポジトリ|レポジトリー/
+  - expected: ルータ
+    pattern:  /ルーター/
+  - expected: レイヤ
+    pattern:  /(プ)?レイヤー/
+    regexpMustEmpty: $1
+    specs:
+      - from: レイヤー
+        to:   レイヤ
+      - from: プレイヤー
+        to:   プレイヤー
+  - expected: レジスタ
+    pattern:  /レジスター/
+  - expected: レジストリ
+    pattern:  /レジストリー/
+  - expected: レイテンシ
+    pattern:  /レイテンシー/
+  - expected: レコメンド
+    pattern:  /リコメンド/
+  - expected: ロータ$1
+    pattern:  /ローター([^ー])/
+  - expected: ローダ
+    pattern:  /ローダー/
+  - expected: ロングテール
+    pattern:  /ロングテイル/
+  - expected: バックアップ$1
+    pattern:  /\bBackup\b([^.])/
+  - expected: スレーブ$1
+    pattern:  /スレイブ([^.])|\bSlave\b([^.])/
+  - expected: 記述子
+    pattern:  /ディスクリプタ/
+  - expected: 属性
+    pattern:  /アトリビュート/
+  - expected: 要素
+    pattern:  /エレメント/
+  - expected: アニメーター
+    pattern:  /アニメータ(?!ー)/
+  - expected: キャラクタ$1
+    pattern:  /キャラクター([^ー])/
+  - expected: コミッター$1
+    pattern:  /コミッタ([^ー])/
+  - expected: ユーザー
+    pattern:  /ユーザ(?!ー)/
+  - expected: ユーザビリティ
+    pattern:  /ユーザービリティ/
+  - expected: ディレクター
+    pattern:  /ディレクタ(?!ー)/
+    specs:
+      - from: ディレクター
+        to:   ディレクター
+  - expected: デザイナー
+    pattern:  /デザイナ(?!ー)/
+  - expected: 開発者
+    pattern:  /デベロッパ|デベロッパー|ディベロッパ|ディベロッパー/
+  - expected: ファシリテーター
+    pattern:  /ファシリテータ(?!ー)/
+  - expected: プレイヤー
+    pattern:  /プレーヤ/
+  - expected: プレーヤ
+    pattern:  /プレーヤー/
+  - expected: プログラマー
+    pattern:  /プログラマ(?!ー)/
+  - expected: プログラマブル
+    pattern:  /プログラマーブル/
+  - expected: プロデューサー$1
+    pattern:  /プロデューサ([^ー])/
+  - expected: プランナー$1
+    pattern:  /プランナ([^ー])/
+  - expected: $1マスタ$2
+    pattern:  /(?:([^ム])マスター)|(?:マスター([^.]))/
+  - expected: $1マスタ$2
+    pattern:  /(?:([^ム])\bMaster)|(?:Master\b([^.]))/
+  - expected: $1マスタ$2
+    pattern:  /(?:([^ム])\bmaster)|(?:master\b([^.]))/
+  - expected: マネージャー$1
+    pattern:  /マネージャ([^ー])/
+  - expected: メンテナー$1
+    pattern:  /メンテナ(?!ンス)([^ー]|)/
+  - expected: メンバー
+    pattern:  /メンバ(?!ー)/
+  - expected: メール
+    pattern:  /email|eメール|E-メール/Eメール/電子メール/
+  - expected: リーダー
+    pattern:  /リーダ(?!ー)/
+  - expected: レビュアー$1
+    pattern:  /レビュア([^ー])|レビュワー([^ー])|レビュワ([^ー])|レビューアー([^ー])|レビューア([^ー])|レビューワー([^ー])|レビューワ([^ー])/
+  - expected: Akamai
+    pattern:  /\bAkamai\b/i
+  - expected: Alias
+    pattern:  /\bAilias\b/
+  - expected: Amazon Web Services$1
+    pattern:  /\bAmazon Web Service\b([^s])/
+  - expected: Android
+    pattern:  /アンドロイド|\bandroid\b/
+  - expected: Apache
+    pattern:  /\bapache\b|\bApatch\b|\bapatch\b/
+  - expected: Apache $1$2
+    pattern:  /Apache([0-9])|Apatch([0-9])/
+  - expected: App Store
+    pattern:  /\bAppStore\bs
+  - expected: Apple
+    pattern:  /アップル/
+  - expected: Apple
+    pattern:  /\bApple\b/i
+  - expected: Backbone.js
+    pattern:  /\bBackbone.js\b/i
+  - expected: Babel
+    pattern:  /\bBabel\b/i
+  - expected: bash
+    pattern:  /\bBash\b/
+  - expected: Bitbucket
+    pattern:  /\bBitbucket\b/i
+  - expected: Bitcoin
+    pattern:  /\bBitcoin\b/i
+  - expected: BlackBerry
+    pattern:  /\bBlackBerry\b/i
+  - expected: Blu-ray
+    pattern:  /\bBlu-ray\b/i
+  - expected: CentOS
+    pattern:  /\bCent OS\b/
+  - expected: Chef
+    pattern:  /\bChef\b/i
+  - expected: Chrome Web Store
+    pattern:  /Chromeウェブストア|Chrome Webストア/
+  - expected: Chromium
+    pattern:  /\bChronium\b/
+  - expected: CloudFlare
+    pattern:  /\bCloudFlare\b/i
+  - expected: Cygwin
+    pattern:  /\bCygwin\b/i
+  - expected: Composer
+    pattern:  /\bComposer\b/i
+  - expected: CSS スプライト
+    pattern:  /CSSスプライト|CSS-Sprite|\bCSS Sprite\b/
+  - expected: Debian GNU/Linux
+    pattern:  /\bDebian\b|Debian\/GNU Linux/
+  - expected: Docker Hub
+    pattern:  /\bDockerHub\b/
+  - expected: Dreamweaver
+    pattern:  /\bDreamWeaver\b/
+  - expected: easy_install
+    pattern:  /\beasy_install\b/i
+  - expected: Eclipse
+    pattern:  /\bEclipse\b/i
+  - expected: ECMAScript
+    pattern:  /\bECMA Script\b/
+  - expected: EJB-JARファイル
+    pattern:  /\bEJB-JARファイル\b/i
+  - expected: Elisp
+    pattern:  /\bElisp\b/i
+  - expected: Lisp
+    pattern:  /\bLisp\b/i
+  - expected: Elixir
+    pattern:  /\bElixr\b|\belixr\b/
+  - expected: Emacs
+    pattern:  /\bEmacs\b/i
+  - expected: Emacs $1
+    pattern:  /Emacs([0-9])/
+  - expected: Emacs Lisp
+    pattern:  /\bEmacs Lisp\b/i
+  - expected: ERB
+    pattern:  /\bERB\b/i
+  - expected: Ethernet
+    pattern:  /イーサネット/
+  - expected: EventMachine
+    pattern:  /\bEventMachine\b/i
+  - expected: Excel
+    pattern:  /エクセル/
+  - expected: Express
+    pattern:  /\bexpress\b/
+  - expected: Fabric
+    pattern:  /\bFablic\b/
+  - expected: $1Facebook$2
+    pattern:  /(?:([^/.])\bfacebook)|(?:facebook\b([^/.]))/
+  - expected: Firebug
+    pattern:  /\bFirebug\b/i
+  - expected: Firefox
+    pattern:  /\bFireFox\b|\bFire Fox\b|ファイアーフォックス|ファイヤーフォックス/
+  - expected: Fitbit
+    pattern:  /\bFitbit\b/i
+  - expected: Flash
+    pattern:  /フラッシュ/
+  - expected: Flash Player
+    pattern:  /Flashプレイヤー|Flash プレイヤー|Flashプレーヤ|Flash プレーヤ|Flashプレーヤー|Flash プレーヤー|\bFlashPlayer\b/
+  - expected: Fluentd
+    pattern:  /\bFluentd\b/i
+  - expected: GitHub Pages
+    pattern:  /\bGitHub Pages\b/i
+  - expected: GitHub Enterprise
+    pattern:  /GH:E|\bGHE\b|GitHub:E/
+  - expected: $1GitHub$2
+    pattern:  /(?:([^/.])\bgithub)|(?:github\b([^/.]))/
+  - expected: $1GitHub$2
+    pattern:  /(?:([^/.])\bGithub)|(?:Github\b([^/.]))/
+  - expected: Git
+    pattern:  /\bGit\b/i
+  - expected: Gmail
+    pattern:  /\bGmail\b/i
+  - expected: Google Gadget
+    pattern:  /Googleガジェット/
+  - expected: Google Maps
+    pattern:  /\bGoogle Map\b|\bGoogleMaps\b|\bGoogleMap\b|Googleマップ/
+  - expected: Greasemonkey
+    pattern:  /\bGreaseMonkey\b|\bGrease monkey\b|\bGrease Monkey\b/
+  - expected: Grunt
+    pattern:  /\bGrunt\b/i
+  - expected: gulp
+    pattern:  /\bgulp\b/i
+  - expected: gzip
+    pattern:  /\bgzip\b/i
+  - expected: Heartbeat
+    pattern:  /\bHeartbeat\b/i
+  - expected: Heroku
+    pattern:  /\bHeroku\b/i
+  - expected: Homebrew
+    pattern:  /\bHomebrew\b/i
+  - expected: HTML5
+    pattern:  /HTML 5/
+  - expected: HTML $1
+    pattern:  /HTML([0-4])/
+  - expected: HTTP/$1
+    pattern:  /HTTP([0-9])/
+  - expected: HTTP/$1
+    pattern:  /HTTP ([0-9])/
+  - expected: Hubot
+    pattern:  /\bHubot\b/i
+  - expected: I/O
+    pattern:  /\bIO\b/
+  - expected: ImageMagick
+    pattern:  /\bImageMagick\b/i
+  - expected: Internet Explorer $1$2
+    pattern:  /Internet Explorer([0-9])|IE([0-9])/
+  - expected: iOS $1
+    pattern:  /iOS([0-9])/
+  - expected: iPhone
+    pattern:  /アイフォン|\biphone\b|\bIPHONE\b/
+  - expected: iPhone 5s
+    pattern:  /\biPhone 5s\b/i
+  - expected: iPhone 4S
+    pattern:  /\biPhone 4S\b/i
+  - expected: ISO
+    pattern:  /ISO-/
+  - expected: ISO $1
+    pattern:  /ISO([0-9])/
+  - expected: iTunes Card
+    pattern:  /\biTunes Card\b/i
+  - expected: iPad
+    pattern:  /\biPad\b/i
+  - expected: iPhone
+    pattern:  /\biPhone\b/i
+  - expected: Java $1
+    pattern:  /Java([0-9])/
+  - expected: Jenkins
+    pattern:  /\bJenkins\b/i
+  - expected: Jetpack
+    pattern:  /\bJetpack\b/i
+  - expected: JPEG
+    pattern:  /\bJPEG\b/i
+  - expected: Kickstarter
+    pattern:  /\bKickstarter\b/i
+  - expected: LESS
+    pattern:  /\bLESS\b/i
+  - expected: LinkedIn
+    pattern:  /\bLinked In\b/
+  - expected: macOS
+    pattern:  /\bMacOS\b|\bMac OS\b|\bmac OS\b|\bOS X\b|\bOSX\b|\bMac OS X\b|\bMacOSX\b/
+  - expected: MacBook
+    pattern:  /\bMac Book\b/
+  - expected: MacPorts
+    pattern:  /\bMacPorts\b/i
+  - expected: Maglica
+    pattern:  /\bMaglica\b/i
+  - expected: MariaDB
+    pattern:  /\bMariaDB\b/i
+  - expected: Markdown
+    pattern:  /\bMarkdown\b/i
+  - expected: MasterCard
+    pattern:  /マスターカード/
+  - expected: Maven
+    pattern:  /\bMaven\b/i
+  - expected: MeCab
+    pattern:  /\bMeCab\b/i
+  - expected: Mechanize
+    pattern:  /\bMechanize\b/i
+  - expected: Meetup
+    pattern:
+    - ミートアップ
+    - meetup
+  - expected: memcached
+    pattern:  /\bmemcached\b/i
+  - expected: $1Microsoft$2
+    pattern:  /(?:([^/.])マイクロソフト)|(?:マイクロソフト([^/.]))/
+  - expected: $1Microsoft$2
+    pattern:  /(?:([^/.])\bmicrosoft)|(?:microsoft\b([^/.]))/
+  - expected: Migemo
+    pattern:  /\bMigemo\b/i
+  - expected: MiniMagick
+    pattern:  /\bMiniMagick\b/i
+  - expected: MongoDB
+    pattern:  /\bMongo DB\b/
+  - expected: msysGit
+    pattern:  /\bmsysGit\b/i
+  - expected: Munin
+    pattern:  /\bMunin\b/i
+  - expected: MySQL
+    pattern:  /\bMySQL\b/i
+  - expected: MySQL $1
+    pattern:  /\bMySQL([0-9])/
+  - expected: Nagios $1
+    pattern:  /Nagios([0-9])/
+  - expected: Nagios
+    pattern:  /\bNagios\b/i
+  - expected: Nokia
+    pattern:  /\bNokia\b/i
+  - expected: nginx
+    pattern:  /\bnginx\b/i
+  - expected: NGINX Plus
+    pattern:  /\bNGINX Plus\b/i
+  - expected: Node.js
+    pattern:  /\bNode.js\b/i
+  - expected: nonce
+    pattern:  /ノンス/
+  - expected: OAuth
+    pattern:  /\bOAuth\b/i
+  - expected: OmniAuth
+    pattern:  /\bOmniAuth\b/i
+  - expected: OpenGL
+    pattern:  /\bOpen GL\b/
+  - expected: Opscode
+    pattern:  /\bOpscode\b/i
+  - expected: Packagist
+    pattern:  /\bPackagist\b/i
+  - expected: Paperclip
+    pattern:  /\bPaperclip\b/i
+  - expected: PayPal
+    pattern:  /\bPayPal\b/i
+  - expected: parallel
+    pattern:  /\bpararllel\b/
+  - expected: PECL
+    pattern:  /\bPECL\b/i
+  - expected: Perl $1
+    pattern:  /Perl([0-9])/
+  - expected: Perl
+    pattern:  /\bPerl\b/i
+  - expected: PhantomJS
+    pattern:  /\bPhantomJS\b/i
+  - expected: Photoshop
+    pattern:  /\bPhotoShop\b|\bphotoshop\b|フォトショップ/
+  - expected: PHP $1
+    pattern:  /PHP([0-9])/
+  - expected: PHPBrew
+    pattern:  /\bPHPBrew\b/i
+  - expected: PHPDoc
+    pattern:  /\bPHPDoc\b/i
+  - expected: PhpMetrics
+    pattern:  /\bPhpMetrics\b/i
+  - expected: PhpStorm
+    pattern:  /\bPhpStorm\b/i
+  - expected: PHPUnit
+    pattern:  /\bPHPUnit\b/
+  - expected: POPFile
+    pattern:  /\bPOPFile\b/i
+  - expected: PostScript
+    pattern:  /\bPostScript\b/i
+  - expected: PostgreSQL $1
+    pattern:  /PostgreSQL([0-9])/
+  - expected: PowerPoint
+    pattern:  /\bPower Point\b/
+#  - expected: Pull Request
+#    pattern:  /プルリクエスト|\bpull request\b|\bPull request\b/
+  - expected: Python
+    pattern:  /\bPython\b/iΩ
+  - expected: RADIUS
+    pattern:  /\bRADIUS\b/i
+  - expected: Rails $1
+    pattern:  /Rails([0-9])/
+  - expected: Rake
+    pattern:  /\bRake\b/i
+  - expected: Raspberry Pi
+    pattern:  /\bRasbpberry Pi\b|\bRaspiberry Pi\b|\bRaspberryPi\b/
+  - expected: Redmine
+    pattern:  /\bRedmine\b/i
+  - expected: Red Hat
+    pattern:  /\bRedHat\b|\bRedhat\b|\bredhat\b|\bRedHad\b|\bRedhad\b|\bredhad\b|レッドハット/
+  - expected: Red Hat Enterprise Linux
+    pattern:  /\bRHEL\b/
+  - expected: Red Hat Linux
+    pattern:  /\bRedHatLinux\b|\bRedHat Linux\b/
+  - expected: Red Hat Linux $1
+    pattern:  /Red Hat Linux([0-9])|RedHatLinux([0-9])|RedHat Linux([0-9])/
+  - expected: Redis
+    pattern:  /\bRedis\b/i
+  - expected: Redshift
+    pattern:  /\bRedshift\b/i
+  - expected: Refile
+    pattern:  /\bRefile\b/i
+  - expected: RELAX NG
+    pattern:  /\bRELAX NG\b/i
+  - expected: RFC $1
+    pattern:  /RFC([0-9])/
+  - expected: 権限グループ
+    pattern:  /ロール/
+  - expected: RRDtool
+    pattern:  /\bRRDtool\b/i
+  - expected: RSpec
+    pattern:  /\bRSpec\b/i
+  - expected: SAML $1
+    pattern:  /SAML([0-9])/
+  - expected: Scheme
+    pattern:  /\bScheme\b/i
+  - expected: Selenium WebDriver
+    pattern:  /\bSelenium WebDriver\b/i
+  - expected: Selenium
+    pattern:  /\bSelenium\b/i
+  - expected: Sequel
+    pattern:  /\bSequel\b/i
+  - expected: Serverspec
+    pattern:  /\bServerspec\b/i
+  - expected: Serverspec
+    pattern:  /\bserver spec\b/
+  - expected: Servlet $1
+    pattern:  /Servlet([0-9])/
+  - expected: Shift_JIS
+    pattern:  /Shift-JIS|SHIFT-JIS|SHIFT_JIS|\bShift JIS\b|Shift_JIS|シフトJIS/
+  - expected: Shrine
+    pattern:  /\bShrine\b/i
+  - expected: Shrpx
+    pattern:  /\bShrpx\b/i
+  - expected: Silverlight
+    pattern:  /\bSilverLight\b|\bSilver Light\b/
+  - expected: SimpleTest
+    pattern:  /\bSimpleTest\b/i
+  - expected: SkeedCast
+    pattern:  /\bSkeedCast\b/i
+  - expected: $1Smalltalk$2
+    pattern:  /(?:([^/.])スモールトーク)|(?:スモールトーク([^/.]))/
+  - expected: Smalltalk
+    pattern:  /\bSmalltalk\b/i
+  - expected: Socket.IO
+    pattern:  /\bSocket.IO\b/i
+  - expected: $1SourceForge
+    pattern:  /([^/.])\bsourceforge\b/
+  - expected: StudioPress
+    pattern:  /\bStudioPress\b/i
+  - expected: SPDY/$1
+    pattern:  /SPDY([0-9])/
+  - expected: SPDY/$1
+    pattern:  /SPDY ([0-9])/
+  - expected: SpiderMonkey
+    pattern:  /\bSpiderMonkey\b/i
+  - expected: SQL $1
+    pattern:  /SQL([0-9])/
+  - expected: SQLite
+    pattern:  /\bSQLite\b/i
+  - expected: $1Subversion$2
+    pattern:  /(?:([^/.])\bSubVersion)|(?:SubVersion\b([^/.]))/
+  - expected: $1Subversion$2
+    pattern:  /(?:([^/.])\bsubversion)|(?:subversion\b([^/.]))/
+  - expected: Tips
+    pattern:  /\bTips\b/i
+  - expected: Tomcat $1
+    pattern:  /Tomcat([0-9])/
+  - expected: Transient
+    pattern:  /トランジェント/
+  - expected: Twitter
+    pattern:  /\bTwitter\b/i
+  - expected: Twitter
+    pattern:  /ツイッター/
+  - expected: ToDo
+    pattern:  /\bToDo\b/i
+  - expected: TypeScript
+    pattern:  /\bTypeScript\b/i
+  - expected: Ubuntu
+    pattern:  /\bubuntu\b|\bUbuntsu\b|\bubuntsu\b|\bUbuntu Linux\b/
+  - expected: Unicode
+    pattern:  /\bunicode\b|ユニコード/
+  - expected: UnixBench
+    pattern:  /\bUnixBench\b/i
+  - expected: UNIX
+    pattern:  /\bUnix\b/
+  - expected: UTF-8
+    pattern:  /UTF8|UTF 8|utf8/
+  - expected: VirtualBox
+    pattern:  /\bVirtual Box\b/
+  - expected: Web
+    pattern:
+      - ウェブ
+      - ウェッブ
+  - expected: Web API
+    pattern:  /\bWebAPI\b|\bWEBAPI\b|\bWEB API\b/
+  - expected: Web UI
+    pattern:  /\bWebUI\b/
+  - expected: Webhook
+    pattern:  /Webフック|Web フック|\bWebHook\b/
+  - expected: WebLogic
+    pattern:  /\bWeb Logic\b/
+  - expected: webpack
+    pattern:  /\bwebpack\b/i
+    specs:
+      - from: Webpack
+        to:   webpack
+  - expected: Wi-Fi
+    pattern:  /\bWiFi\b|Wi-fi|wi-fi/
+  - expected: WordCamp
+    pattern:  /\bWordCamp\b/i
+  - expected: WordPress
+    pattern:  /\bWordPress\b/i
+  - expected: WordPress $1
+    pattern:  /WordPress([0-9])/i
+  - expected: $1Word
+    pattern:  /([^ースォ])ワード/
+  - expected: Xcode
+    pattern:  /\bXcode\b/i
+  - expected: Xdebug
+    pattern:  /\bXdebug\b/i
+  - expected: XML Schema
+    pattern:  /\bXML Schema\b/i
+  - expected: Yahoo!$1
+    pattern:  /YAHOO!([^!.])|\bYahoo\b([^!.])|\bYAHOO\b([^!.])|ヤフー([^!.])/
+  - expected: YouTube
+    pattern:  /\bYoutube\b|\byoutube\b/
+  - expected: YSlow
+    pattern:  /\bYSlow\b/i
+  - expected: ZIPファイル
+    pattern:  /\bZIPファイル\b/i
+  - expected: を
+    pattern:  /をを/
+  - expected: に
+    pattern:  /にに/
+  - expected: が
+    pattern:  /がが/
+  - expected: する
+    pattern:  /するする/
+  - expected: て
+    pattern:  /(当)?てて/
+    regexpMustEmpty: $1
+  - expected: で
+    pattern:  /でで/
+  - expected: $1の
+    pattern:  /([^も])のの/
+  - expected: は
+    pattern:  /はは/


### PR DESCRIPTION
Fix: #14

PR 時や master へのマージ時に、あらかじめ設定したルールをもとに機械的なチェックをかけられるようにするため、[textlint](https://github.com/textlint/textlint) とそれを自動実行する GitHub Actions を導入しました。

## 検出できるルール

- 全角スペース、半角スペースの連続を禁止
例: `　` → ` `、`  ` → ` `
- 英数字は半角文字を使う
例: `０～９` → `0～9`
- 符号、疑問符、感嘆符、丸括弧、コロンには半角文字を使う
例: `＋－＝＜＞？！（）：` → `+-=<>?!():`
- 疑問符、感嘆符の前に半角スペースを入れる 
例: `準備ができましたか?` → `準備ができましたか?`
- 丸括弧の内側に半角スペースを入れない
例: `山田さん ( 30歳 )` → `山田さん (30歳)`
- 丸括弧の前に半角スペースを入れる (例外として。、は除く)
例: `山田さん(30歳)` → `山田さん (30歳)`
- 丸括弧の前に半角スペースを入れない (。、)
例: `山田さん。 (30歳)` → `山田さん。(30歳)`
- 丸括弧の後に半角スペースを入れる (例外として。、は除く)
例: `山田さん (30歳)のコメント` → `山田さん (30歳) のコメント`
- 丸括弧の後に半角スペースを入れない (。、)
例: `山田さん (30歳) 。` → `山田さん (30歳)。`
- コロンの前に半角スペースを入れない
例: `ユーザー ID : username` → `ユーザー ID: username`
- コロンの後に半角スペースを入れる
例: `ユーザー ID:username` → `ユーザー ID: username`
- 丸括弧内には句点は付けない
例: `山田さん (30歳。)` → `山田さん (30歳)`
- 半角数字の前後には半角スペースを入れない
例: `この商品は 300 円です。` → `この商品は300円です。`

## 検出できないルール

- 日本語の句読点には全角の「。」と「、」を使う
理由: 「.」と「,」はURLやコード内でも使われることがあり、機械的にはそれらが句読点であるかどうかを判別できないため。

- 丸括弧が末尾にくる場合は、括弧の外に句点を付ける
理由: 見出し行 (# 記号はじまり)は、例外的に丸括弧が末尾にくる事を許容しているが、これを除外する適切な正規表現が見つからなかったため
例: `# 国際化 (i18n)`

## 手動実行

リポジトリをローカルにクローンしている方は、以下のように手動で特定のファイルをチェックすることもできます。

- npmパッケージのインストール: `npm ci`
- ファイルを指定してチェックする: `npm run textlint ./core/path/to/file.md`

## 懸念点

- すべてのマークダウンファイルがチェック対象となるため、未翻訳のドキュメントが残っていると大量にエラーが出てしまう。
- また、翻訳スタイルガイドには沿っているが機械的にエラーとなるケースは完全に無くせないと思うので、GitHub Actions が毎回コケてしまうのは少し気持ち悪い。
GitHub アクションはやめて、ローカルでの手動コマンド実行のみに絞った方が良いかもしれない。
