### PR TITLE
textlint ルール更新

### DIFF
--- a/prh-rules/wordpress.yml
+++ b/prh-rules/wordpress.yml
@@ -66,6 +66,8 @@ rules:
   # 半角英字と全角文字の間には、半角スペースを入れる
   - pattern: /([^\x01-\x7E])([a-zA-Z]+)([^\x01-\x7E])/
     expected: $1 $2 $3
+  - pattern: /^([a-zA-Z]+)([^\x01-\x7E])/
+    expected: $1 $2
   # 疑問符、感嘆符の前に半角スペースを入れる
   - pattern: /([^ ])([!?])/
     expected: $1 $2
@@ -2175,7 +2177,7 @@ rules:
   - expected: マネージャー$1
     pattern:  /マネージャ([^ー])/
   - expected: メンテナー$1
-    pattern:  /メンテナ(?!ンス)([^ー]|)/
+    pattern:  /メンテナ([^ーンス])/
   - expected: メンバー
     pattern:  /メンバ(?!ー)/
   - expected: メール


### PR DESCRIPTION
以下のように、textlint のルールを更新しました。

## 半角英字と全角文字の間には、半角スペースを入れる
文頭が半角英字からはじまった場合でも検出できるように変更

## カタカナ語 - 長音記号「−」は、長音を含めて4文字以下になる単語には付ける

❌ メンテナ → ✅ メンテナー

「メンテナー」と正しく入力していても、エラーとして検出される問題を修正