### PR TITLE
原文の更新・反映方法を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,63 @@ GitHub が初めての方も [翻訳開始から提案までの流れ](https://g
 
 翻訳の表記ゆれなど、その他迷った時は Issue を立てるか、 [WordPress 日本語 Slack](http://bit.ly/join-wordslack) の docs チャンネルまでご相談ください。
 
-## 原文更新方法
+## 原文の更新・反映方法
 
-1.  `en` ブランチから `en20210905` などのブランチを作成します。
-2.  原文を更新します。[wp-handbook-converter](https://github.com/mirucon/wp-handbook-converter)を使うことをオススメします。
+### en ブランチでの原文更新
 
-`npx wp-handbook-converter core --sub-domain make`
+**注意: `en` ブランチには、日本語訳は含めないでください。**
 
-3.  `en` ブランチにプルリクエストします。差分を確認して問題なければマージしてください。
+まずは `en` ブランチで、[wp-handbook-converter](https://github.com/mirucon/wp-handbook-converter) を使用し、原文を更新します。
 
-_`en` ブランチには翻訳を含めないでください。_
+1. `en` ブランチをチェックアウトします。
 
-4. `en` から `main` にプルリクをおくります。差分を確認し、問題なければ、 `main` にマージし、更新完了です。`en`ブランチは削除しないでください。
+    ```
+    git fetch origin en
+    git checkout en
+    ```
+
+2. [wp-handbook-converter](https://github.com/mirucon/wp-handbook-converter)を使って原文を更新します。`--output-dir` オプションで、出力先を `core` に指定します。また `--regenerate` オプションで、出力先ディレクトリを一度削除するようにします。
+    ```
+    npx wp-handbook-converter --team core --output-dir core --regenerate
+    ```
+
+3. `git diff` コマンドなどを使って、原文の差分を確認します。
+
+4. 問題がなければ、`en` ブランチで原文の更新を commit し、リモートブランチに push します。
+
+    ```
+    git add .
+    git commit -m "原文を更新"
+    git push origin en
+    ```
+
+### 日本語化ファイルの反映
+
+日本語化済みの情報を最新の原文に反映させます。
+
+1. `en` ブランチから、作業用のブランチ (例: update-document) をチェックアウトします。
+    ```
+    git checkout -b update-document
+    ```
+
+2. `main` ブランチにある、日本語化済の情報を取り込みます。
+    ```
+    git merge main
+    ```
+
+3. コンフリクトが発生した場合は解消します。コンフリクトが発生しているファイルは、`git status` コマンドを実行した時に、`Unmerged paths` として表示されています。または、「`<<<<<<< HEAD`」などのコマンドでコンフリクトが発生している箇所を探します。
+
+4. 全てのコンフリクトを解消したら、commit し、リモートブランチに push します。
+    ```
+    git add .
+    git commit -m "原文を更新"
+    git push origin update-document
+    ```
+
+### プルリクエストの作成
+
+1. 最新の原文、および日本語化済の情報を含んだブランチ (例: `update-document`) から、プルリクエストを作成します。
+
+2. 差分を確認し、問題なければ `main` ブランチにマージします。
+
+**注意: 作業用のリモートブランチ (例: `update-document`)は削除しても構いませんが、`en` ブランチは削除しないでください。**


### PR DESCRIPTION
原文の更新方法を変更しました。

## 問題点

現状の方法では、以下の順で各ブランチに対してPRを発行している。

1. `enYYYYMMDD` → `en`
2. `en` → `main`

2.のPRにおいて、`main` ブランチとの間でコンフリクトが発生する事があるが、GitHub 上でコンフリクトを解消すると、`main` → `en` ブランチに merge が行われるので、`main` ブランチの日本語訳が `en` ブランチにも反映されてしまう。

## 変更後

- `en` ブランチは、単純に原文を更新するだけのブランチとし、PRには使用しない。
- `main` へのPRは、`en` ブランチからチェックアウトした作業用ブランチから行う (PR時に発生したコンフリクトを解消しても、`en` ブランチには影響が無い)

詳細な手順は[こちら](https://github.com/jawordpressorg/core-handbook/tree/update/readme-git#%E5%8E%9F%E6%96%87%E3%81%AE%E6%9B%B4%E6%96%B0%E5%8F%8D%E6%98%A0%E6%96%B9%E6%B3%95)です。