### PR TITLE
translate core/about/release-cycle/version-numbering.md

### DIFF
--- a/core/about/release-cycle/version-numbering.md
+++ b/core/about/release-cycle/version-numbering.md
@@ -1,11 +1,34 @@
+<!--
 # Version Numbering
+-->
 
+# バージョン番号の付け方
+
+<!--
 A **major** WordPress version is dictated by the first two sequences. For example, **3.5** is a major release. So is **3.6**, **3.7**, all the way up to **4.0**. Version **4.0** is no different than **3.9** and **4.1**. There isn’t a “WordPress 3” or “WordPress 4” – we’re weird like that for historical reasons.
+-->
 
+WordPress の**メジャー**バージョンは、最初の2つのシーケンスによって決定されます。たとえば、**3.5**はメジャーリリースです。**3.6**、**3.7**、そして**4.0**までがそうです。バージョン**4.0**は、**3.9**や**4.1**と何ら変わりません。「WordPress3」や「WordPress4」は存在しませんが、歴史的な理由からそうなっているのです。
+
+<!--
 Major releases add new user features and developer APIs. Though typically a “major” version means you can break backwards compatibility (and indeed, it normally means that you have), WordPress strives to *never* break backwards compatibility. It’s one of our most important philosophies, and makes updates much easier on users and developers alike.
+-->
 
+メジャーリリースでは、新しいユーザー機能や開発者向け API が追加されます。一般的に「メジャー」バージョンは後方互換性を破壊することを意味しますが、WordPress は後方互換性を「決して」壊さないように努めています。これは私たちの最も重要な哲学の一つであり、ユーザーと開発者双方にとってアップデートがより簡単になります。
+
+<!--
 A **minor** WordPress version is dictated by the third sequence. Version **3.9.1** is a minor release. So is **3.8.2**. A minor release is intended for bugfixes and enhancements that do not add new deployed files and are at the discretion of the release lead with suggestions/input from component maintainers and committers.
+-->
 
-Since new versions of WordPress are released so frequently – we aim for 4-5 months for a major release, and minor releases happen as needed – we only have a need for major and minor releases. We don’t have bug\-fix or “patch” releases you normally see with an X.Y.Z-style version number. Rather, we have an X.X.Y version number.
+WordPress の**マイナー**バージョンは、3番目のシーケンスで指示されます。バージョン**3.9.1**はマイナーリリースです。**3.8.2**もそうです。マイナーリリースは、新しいファイルを追加しないバグ修正と機能強化を目的としており、コンポーネントのメンテナーやコミッターからの提案や意見を参考に、リリースリードの裁量で決定されます。
 
+<!-- Since new versions of WordPress are released so frequently – we aim for 4-5 months for a major release, and minor releases happen as needed – we only have a need for major and minor releases. We don’t have bug\-fix or “patch” releases you normally see with an X.Y.Z-style version number. Rather, we have an X.X.Y version number. -->
+
+WordPress の新バージョンは頻繁にリリースされるため、メジャーリリースは4～5ヶ月、マイナーリリースは必要に応じて行われます。メジャーリリースとマイナーリリースのみが必要なのです。X.Y.Z 形式のバージョン番号で通常表示されるバグ修正や「パッチ」リリースは行いません。X.X.Y のバージョン番号なのです。
+
+<!--
 While it’s a bit confusing, our commitments to backwards compatibility and fast release cycles make it very easy for users to be able to update without worrying. (Which is great, considering the days of the version number [are numbered](http://www.codinghorror.com/blog/2011/05/the-infinite-version.html)…)
+-->
+
+少し分かりにくいですが、後方互換性と速いリリースサイクルへの対応により、ユーザーが心配することなくアップデートできるように非常に簡単になっています。(バージョン番号の時代が[終わりつつある]((http://www.codinghorror.com/blog/2011/05/the-infinite-version.html))ことを考えると、これはすばらしいことです。
+)


### PR DESCRIPTION
#62 を対応しました。

日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/translate/about-release-cycle-version-numbering/core/about/release-cycle/version-numbering.md
英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/about/release-cycle/version-numbering.md
英語 Web ページ: https://make.wordpress.org/core/handbook/about/release-cycle/version-numbering/
