### PR TITLE
translate about/release-cycle.md

### DIFF
--- a/core/about/release-cycle.md
+++ b/core/about/release-cycle.md
@@ -1,19 +1,55 @@
+<!--
 # How the Release Cycle Works
+-->
 
+# リリースサイクルのしくみ
+
+<!--
 Each WordPress release cycle is led by one (or more) of the core WordPress developers.
+-->
 
+WordPress の各リリースサイクルは、WordPress のコア開発者の一人 (またはそれ以上) が主導しています。
+
+<!--
 A release cycle usually lasts around 4 months from the initial scoping meeting to launch of the version.
+-->
 
+リリースサイクルは、最初のスコープミーティングからバージョンのローンチまで、通常4ヶ月程度です。
+
+<!--
 The [5.7 release cycle](https://make.wordpress.org/core/5-7/) ended on March 7, 2021.
+-->
 
+[5.7のリリースサイクル](https://make.wordpress.org/core/5-7/)は、2021年3月7日に終了しました。
+
+<!--
 A release cycle follows the following pattern:
+-->
 
+リリースサイクルは次のようなパターンで行われます。
+
+<!--
 *   **Phase 1: Planning and securing team leads.** This is done in the **[#core](https://wordpress.slack.com/messages/C02RQBWTW)** channel. The release lead discusses features for the next release of WordPress. WordPress contributors get involved with that discussion. The release lead will identify focus leads for each of the features.
 *   **Phase 2: Development work begins.** Focus leads assemble teams and work on their assigned features. Regular chats are scheduled to ensure the development keeps moving forward.
 *   **Phase 3:** **Beta.** Betas are released and beta-testers are asked to start reporting bugs. No more commits for new enhancements or feature requests are allowed for the rest of the release.
 *   **Phase 4: Release Candidate.** There is a string freeze from this point on. Work is targeted on regressions and blockers only.
 *   **Phase 5: Launch.** WordPress version is launched and made available in the WordPress Admin for updates.
+-->
 
+*   **フェーズ1: チームリードの企画と確保。** これは、**[#core](https://wordpress.slack.com/messages/C02RQBWTW)** チャンネルで行われます。リリースリードは、WordPress の次のリリースのための機能を議論します。WordPress のコントリビューターはその議論に参加します。リリースリードは、各機能のフォーカスリードを確認します。
+*   **フェーズ2: 開発開始。** フォーカスリードはチームを編成し、担当する機能に取り組みます。定期的にチャットが行われ、開発が常に前進していることを確認します。
+*   **フェーズ3:** **ベータ版。** ベータ版がリリースされ、ベータテスターはバグの報告を開始するよう求められます。このリリースの間は、新しい機能強化や機能要求のコミットは禁止されています。
+*   **フェーズ4: リリース候補版。** この時点から、翻訳文字列がソフトフリーズとなります。作業はリグレッションとブロッカーのみを対象とします。
+*   **フェーズ5: ローンチ。** WordPress のバージョンアップをがリリースされ、WordPress の管理画面で更新できるようにします。
+
+<!--
 The launch is often followed soon after by a minor release (also known as a point release) as bugs are reported and squashed. A minor release is intended for bugfixes and enhancements that do not add new deployed files and are at the discretion of the release lead with suggestions/input from component maintainers and committers.
+-->
 
+バグが報告され、修正されると、マイナーリリース (ポイントリリース) が行われることがよくあります。マイナーリリースは、新しいファイルを追加しないバグ修正と機能強化を目的としており、コンポーネントのメンテナーやコミッターからの提案や意見を参考に、リリースリードの裁量で決定されます。
+
+<!--
 You can learn more about the current release cycle on the [development blog](https://make.wordpress.org/core/).
+-->
+
+現在のリリースサイクルについては、[開発ブログ](https://make.wordpress.org/core/)で詳しく知ることができます。


### PR DESCRIPTION
#63 を対応しました。

日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/translate/about-release-cycle/core/about/release-cycle.md
英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/about/release-cycle.md
英語 Web ページ: https://make.wordpress.org/core/handbook/about/release-cycle/