### PR TITLE
Unify translation of the word `update`

### DIFF
--- a/core/about/philosophies.md
+++ b/core/about/philosophies.md
@@ -80,7 +80,7 @@ We're never done with simplicity. We want to make WordPress easier to use with e
 In past releases, we've taken major steps to improve ease of use and ultimately make things simpler to understand. One great example of this is core software updates. Updating used to be a painful, manual task that was too tricky for a lot of our users. We decided to focus on this, and simplified it down to a single click. Now anyone with a WordPress install can perform one click upgrades on both the core of WordPress, and plugins and themes.
 -->
 
-これまでのリリースでは、使い勝手を向上させ最終的にはよりシンプルに理解できるような工夫をしてきました。その良い例が、コアソフトウェアのアップデートです。以前のアップデートは手間のかかる手作業で、多くのユーザーにとって厄介なものでした。私たちはこれに焦点を当てることにし、ワンクリックで済むように簡略化しました。WordPress をインストールしている人なら誰でも、WordPress のコア、プラグインとテーマの両方をワンクリックでアップグレードできるようになりました。
+これまでのリリースでは、使い勝手を向上させ最終的にはよりシンプルに理解できるような工夫をしてきました。その良い例が、コアソフトウェアの更新です。以前の更新は手間のかかる手作業で、多くのユーザーにとって厄介なものでした。私たちはこれに焦点を当てることにし、ワンクリックで済むように簡略化しました。WordPress をインストールしている人なら誰でも、WordPress のコア、プラグインとテーマの両方をワンクリックでアップグレードできるようになりました。
 
 <!--
 We love to challenge ourselves and simplify tasks in ways that are positive for the overall WordPress user experience. Every version of WordPress should be easier and more enjoyable to use than the last.

--- a/core/about/release-cycle/version-numbering.md
+++ b/core/about/release-cycle/version-numbering.md
@@ -14,7 +14,7 @@ WordPress の**メジャー**バージョンは、最初の2つのシーケン�
 Major releases add new user features and developer APIs. Though typically a “major” version means you can break backwards compatibility (and indeed, it normally means that you have), WordPress strives to *never* break backwards compatibility. It’s one of our most important philosophies, and makes updates much easier on users and developers alike.
 -->
 
-メジャーリリースでは、新しいユーザー機能や開発者向け API が追加されます。一般的に「メジャー」バージョンは後方互換性を破壊することを意味しますが、WordPress は後方互換性を「決して」壊さないように努めています。これは私たちの最も重要な哲学の一つであり、ユーザーと開発者双方にとってアップデートがより簡単になります。
+メジャーリリースでは、新しいユーザー機能や開発者向け API が追加されます。一般的に「メジャー」バージョンは後方互換性を破壊することを意味しますが、WordPress は後方互換性を「決して」壊さないように努めています。これは私たちの最も重要な哲学の一つであり、ユーザーと開発者双方にとって更新がより簡単になります。
 
 <!--
 A **minor** WordPress version is dictated by the third sequence. Version **3.9.1** is a minor release. So is **3.8.2**. A minor release is intended for bugfixes and enhancements that do not add new deployed files and are at the discretion of the release lead with suggestions/input from component maintainers and committers.
@@ -30,5 +30,5 @@ WordPress の新バージョンは頻繁にリリースされるため、メジ�
 While it’s a bit confusing, our commitments to backwards compatibility and fast release cycles make it very easy for users to be able to update without worrying. (Which is great, considering the days of the version number [are numbered](http://www.codinghorror.com/blog/2011/05/the-infinite-version.html)…)
 -->
 
-少し分かりにくいですが、後方互換性と速いリリースサイクルへの対応により、ユーザーが心配することなくアップデートできるように非常に簡単になっています。(バージョン番号の時代が[終わりつつある]((http://www.codinghorror.com/blog/2011/05/the-infinite-version.html))ことを考えると、これはすばらしいことです。
+少し分かりにくいですが、後方互換性と速いリリースサイクルへの対応により、ユーザーが心配することなく更新できるように非常に簡単になっています。(バージョン番号の時代が[終わりつつある]((http://www.codinghorror.com/blog/2011/05/the-infinite-version.html))ことを考えると、これはすばらしいことです。
 )

--- a/core/contribute/codebase.md
+++ b/core/contribute/codebase.md
@@ -190,7 +190,7 @@ Once this is done, you’ll be taken to `wp-admin/install.php`. At this point, t
 Database upgrade instructions are included in `wp-admin/includes/upgrade.php`. Whenever a database change is needed with a new version of WordPress – whether that means altering the database structure, or updating some database content – an upgrade routine can be triggered. Indeed, you can safely update from WordPress 0.70 to the latest version and the database will keep up with the more than a decade of changes.
 -->
 
-データベースのアップグレード方法は `wp-admin/includes/upgrade.php` に記載されています。データベース構造の変更でもデータベースの一部のコンテンツの更新でも、WordPress の新しいバージョンでデータベースの変更が必要なときは、いつでもアップグレードルーチンを起動できます。実際に、WordPress 0.70から最新バージョンに安全にアップデートでき、データベースは10年以上の変化にも対応します。
+データベースのアップグレード方法は `wp-admin/includes/upgrade.php` に記載されています。データベース構造の変更でもデータベースの一部のコンテンツの更新でも、WordPress の新しいバージョンでデータベースの変更が必要なときは、いつでもアップグレードルーチンを起動できます。実際に、WordPress 0.70から最新バージョンに安全に更新でき、データベースは10年以上の変化にも対応します。
 
 <!--
 Knowing *when* to upgrade is handled by a number in `wp-includes/version.php`, the WordPress database version. This number corresponds to a revision number of the codebase, generally the revision that last introduced a database upgrade routine. When the number in the code differs from the number stored in the database, the routines in `wp-admin/includes/upgrade.php` are run.
@@ -214,7 +214,7 @@ Changes to the database structure are handled by a function called `dbDelta()`, 
 ## File Updates
 -->
 
-## ファイルのアップデート
+## ファイルの更新
 
 <!--
 Core developers generally distinguish between database “upgrades” and version “updates.” Updating WordPress to the newest codebase (via the user interface) triggers a complex series of actions.
@@ -226,7 +226,7 @@ Core developers generally distinguish between database “upgrades” and versio
 Prior to any update, WordPress has already polled **api.wordpress.org** to determine whether it needs to update, and if so, where to find the new version. Once the update is triggered, WordPress will download the ZIP archive and unzip it into a temporary directory in **wp-content/upgrade**. A single file, `wp-admin/includes/update-core.php`, will be copied out of the temporary directory and over the existing `wp-admin/includes/update-core.php`, at which point it will be executed. Thus, the newly downloaded code handles the main process of copying over the new files. This allows us to provide instructions specific to the new version, such as which files are old and can be removed.
 -->
 
-アップデートに先立ち、WordPress は **api.wordpress.org** に問い合わせ、アップデートが必要かどうか、必要な場合は新しいバージョンをどこで入手できるかを判断しています。アップデートが開始されると、WordPress は ZIP アーカイブをダウンロードし、**wp-content/upgrade** にある一時ディレクトリに解凍されます。一つのファイルである `wp-admin/includes/update-core.php` が一時ディレクトリからコピーされ、既存の `wp-admin/includes/update-core.php` を上書きし、その時点でそれが実行されます。このように、新しくダウンロードされたコードは、新しいファイルをコピーする主要な処理を行います。これにより、どのファイルが古くて削除できるのかといった、新しいバージョンに特有の指示を出すことができます。
+更新に先立ち、WordPress は **api.wordpress.org** に問い合わせ、更新が必要かどうか、必要な場合は新しいバージョンをどこで入手できるかを判断しています。更新が開始されると、WordPress は ZIP アーカイブをダウンロードし、**wp-content/upgrade** にある一時ディレクトリに解凍されます。一つのファイルである `wp-admin/includes/update-core.php` が一時ディレクトリからコピーされ、既存の `wp-admin/includes/update-core.php` を上書きし、その時点でそれが実行されます。このように、新しくダウンロードされたコードは、新しいファイルをコピーする主要な処理を行います。これにより、どのファイルが古くて削除できるのかといった、新しいバージョンに特有の指示を出すことができます。
 
 <!--
 ## Exploring The Code


### PR DESCRIPTION
[WordSlackのスレッドの議論](https://wpja.slack.com/archives/CRF0HNDS8/p1670591143510069)を元に「update」の翻訳を「更新」に統一しました。
こちらは合意が取れているため、マージします。