### PR TITLE
translate/tutorials/installing-a-local-server/xampp.md

### DIFF
--- a/core/tutorials/installing-a-local-server/xampp.md
+++ b/core/tutorials/installing-a-local-server/xampp.md
@@ -68,7 +68,7 @@ Next, you need to open the folder where you saved the file, and double-click the
 You will be prompted to select the language you wish to use in XAMPP. **Click the arrow** in the dropdown box, **select your language** in the list, then **click OK** to continue the installation process.
 -->
 
-XAMPP で使用する言語を選択するようプロンプトが表示されます。ドロップダウンボックスの**矢印をクリック**し、リストで**言語を選択**し、**OK をクリック**してインストール作業を続行してください。
+XAMPP で使用する言語を選択するプロンプトが表示されます。ドロップダウンボックスの**矢印をクリック**し、リストで**言語を選択**し、**OK をクリック**してインストール作業を続行してください。
 
 <!--
 ![Installing XAMPP: Select Your Language Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-1.png)
@@ -484,7 +484,7 @@ You can shut down XAMPP from the main control panel by **clicking Stop** next to
 **Helpful tip:** You can also shut down XAMPP from the systray icon. **Right-click the XAMPP icon**, and a context menu will appear. Hover over the first service running, then **click Stop**. The green light will turn red once it has stopped. Repeat for the other services running, then **click Quit** to exit the program.
 -->
 
-**Helpful tip:** システムトレイのアイコンからも XAMPP をシャットダウンできます。**XAMPP のアイコンを右クリック**すると、コンテキストメニューが表示されます。最初に起動しているサービスにカーソルを合わせ、**停止をクリック**してください。停止すると、緑のランプが赤に変わります。他のサービスも同様に実行し、**終了をクリック**してプログラムを終了してください。
+**役立つヒント:** システムトレイのアイコンからも XAMPP をシャットダウンできます。**XAMPP のアイコンを右クリック**すると、コンテキストメニューが表示されます。最初に起動しているサービスにカーソルを合わせ、**停止をクリック**してください。停止すると、緑のランプが赤に変わります。他のサービスも同様に実行し、**終了をクリック**してプログラムを終了してください。
 
 <!--
 ![XAMPP Shutdown: Context Menu Screen](https://make.wordpress.org/core/files/2013/03/stopping-xampp-2.png)

--- a/core/tutorials/installing-a-local-server/xampp.md
+++ b/core/tutorials/installing-a-local-server/xampp.md
@@ -1,152 +1,452 @@
+<!--
 # Installing XAMPP
+-->
 
+# XAMPP のインストール
+
+<!--
 ## Overview
+-->
 
+## 概要
+
+<!--
 [XAMPP](http://www.apachefriends.org/en/xampp.html) is an easy to install Apache distribution containing MySQL, PHP and Perl. There are packages for [Windows](http://www.apachefriends.org/en/xampp-windows.html), [Mac](http://www.apachefriends.org/en/xampp-macosx.html), and [Linux](http://www.apachefriends.org/en/xampp-linux.html).
+-->
 
+[XAMPP](http://www.apachefriends.org/en/xampp.html) は、MySQL、PHP、Perl を含む、簡単にインストールできる Apache ディストリビューションです。[Windows](http://www.apachefriends.org/en/xampp-windows.html)、[Mac](http://www.apachefriends.org/en/xampp-macosx.html)、[Linux](http://www.apachefriends.org/en/xampp-linux.html) 用のパッケージが用意されています。
+
+<!--
 This article will walk you through the steps to install XAMPP on your computer.
+-->
 
+この記事では、コンピューターに XAMPP をインストールする手順を説明します。
+
+<!--
 Note: These are the Windows installation instructions – see the Apache Friends website for the [Mac](http://www.apachefriends.org/en/xampp-macosx.html) and [Linux](http://www.apachefriends.org/en/xampp-linux.html) installation instructions.
+-->
 
+備考: これらは Windows のインストール手順です。[Mac](http://www.apachefriends.org/en/xampp-macosx.html) と [Linux](http://www.apachefriends.org/en/xampp-linux.html) のインストール手順については、Apache Friends の Web サイトを参照してください。
+
+<!--
 ## Installing XAMPP
+-->
 
+## XAMPP のインストール
+
+<!--
 ### 1\. Downloading XAMPP
+-->
 
+### 1\. XAMPP のダウンロード
+
+<!--
 Download the installer file for the [latest version of XAMPP](http://www.apachefriends.org/en/xampp-windows.html#641), and save the file to your computer.
+-->
 
+[XAMPP の最新版](http://www.apachefriends.org/en/xampp-windows.html#641)のインストーラファイルをダウンロードし、パソコンに保存してください。
+
+<!--
 ![Download XAMPP Screen](https://make.wordpress.org/core/files/2013/03/download-xampp.png)
+-->
 
+![XAMPP のダウンロード画面](https://make.wordpress.org/core/files/2013/03/download-xampp.png)
+
+<!--
 ### 2\. Installing XAMPP
+-->
 
+### 2\. XAMPP のインストール
+
+<!--
 Next, you need to open the folder where you saved the file, and double-click the installer file.
+-->
 
+次に、ファイルを保存したフォルダーを開き、インストーラファイルをダブルクリックしてください。
+
+<!--
 You will be prompted to select the language you wish to use in XAMPP. **Click the arrow** in the dropdown box, **select your language** in the list, then **click OK** to continue the installation process.
+-->
 
+XAMPP で使用する言語を選択するようプロンプトが表示されます。ドロップダウンボックスの**矢印をクリック**し、リストで**言語を選択**し、**OK をクリック**してインストール作業を続行してください。
+
+<!--
 ![Installing XAMPP: Select Your Language Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-1.png)
+-->
 
+![XAMPP のインストール: 言語を選択する画面](https://make.wordpress.org/core/files/2013/03/installing-xampp-1.png)
+
+<!--
 For Windows 7 users, you will see a window pop up, warning you about User Account Control (UAC) being active on your system. **Click OK** to continue the installation.
+-->
 
+Windows 7をお使いの場合、ユーザーアカウント制御 (UAC) がシステム上で有効であることを警告するウィンドウがポップアップ表示されます。**OK をクリック**して、インストールを続行します。
+
+<!--
 ![Installing XAMPP: UAC Warning Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-2.png)
+-->
 
+![XAMPP のインストール: UAC の警告画面](https://make.wordpress.org/core/files/2013/03/installing-xampp-2.png)
+
+<!--
 Next you will see the Welcome To The XAMPP Setup Wizard screen. **Click Next** to continue the installation.
+-->
 
+次に、「XAMPP セットアップウィザードへようこそ」画面が表示されます。**次へをクリック**してインストールを続行します。
+
+<!--
 ![Installing XAMPP: Welcome To The XAMPP Setup Wizard Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-3.png)
+-->
 
+![XAMPP のインストール: 「XAMPP セットアップウィザードへようこそ」画面](https://make.wordpress.org/core/files/2013/03/installing-xampp-3.png)
+
+<!--
 The Choose Components screen will appear next. This screen will allow you to choose which components you would like to install. To run XAMPP properly, all components checked need to be installed. **Click Next** to continue.
+-->
 
+次に、「コンポーネントの選択」画面が表示されます。この画面では、インストールするコンポーネントを選択できます。XAMPP を正しく動作させるためには、チェックしたコンポーネントをすべてインストールする必要があります。**次へをクリック**して続行します。
+
+<!--
 ![Installing XAMPP: Choose Components Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-4.png)
+-->
 
+![XAMPP のインストール: 「コンポーネントの選択」画面](https://make.wordpress.org/core/files/2013/03/installing-xampp-4.png)
+
+<!--
 Next you will see the Choose Install Location screen. Unless you would like to install XAMPP on another drive, you should not need to change anything. **Click Install** to continue.
+-->
 
+次に、「インストール先の選択」画面が表示されます。XAMPP を他のドライブにインストールしたいのでなければ、何も変更する必要はありません。**インストールをクリック**し、続行します。
+
+<!--
 ![Installing XAMPP: Choose Install Location Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-5.png)
+-->
 
+![XAMPP のインストール: 「インストール先の選択」画面](https://make.wordpress.org/core/files/2013/03/installing-xampp-5.png)
+
+<!--
 XAMPP will begin extracting files to the location you selected in the previous step.
+-->
 
+XAMPP は、前のステップで選択した場所にファイルの展開を開始します。
+
+<!--
 ![Installing XAMPP: Unpacking Files Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-6.png)
+-->
 
+![XAMPP のインストール: ファイル解凍の画面](https://make.wordpress.org/core/files/2013/03/installing-xampp-6.png)
+
+<!--
 Once all of the files have been extracted, the Completing The XAMPP Setup Wizard screen will appear. **Click Finish** to complete the installation.
+-->
 
+すべてのファイルが解凍されると、「XAMPP セットアップウィザードの完了」画面が表示されます。**完了をクリック**して、インストールを完了します。
+
+<!--
 ![Installing XAMPP: Completing The XAMPP Setup Wizard Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-7.png)
+-->
 
+![XAMPP のインストール: 「XAMPP セットアップウィザードの完了」画面](https://make.wordpress.org/core/files/2013/03/installing-xampp-7.png)
+
+<!--
 The Installation Complete screen will now appear. **Click Finish** to begin using XAMPP.
+-->
 
+これで「インストールの完了」画面が表示されます。XAMPP の使用を開始するには、**完了をクリック**してください。
+
+<!--
 ![Installing XAMPP: Installation Complete Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-81.png)
+-->
 
+![XAMPP のインストール: 「インストールの完了」画面](https://make.wordpress.org/core/files/2013/03/installing-xampp-81.png)
+
+<!--
 After clicking Finish in the previous screen, you will be asked if you want to open the XAMPP Control Panel. **Click Yes**.
+-->
 
+前の画面で「完了」をクリックすると、XAMPP コントロールパネルを開くかどうか尋ねられます。**はいをクリック**します。
+
+<!--
 ![Installing XAMPP: Open Control Panel Screen](https://make.wordpress.org/core/files/2013/03/installing-xampp-9.png)
+-->
 
+![XAMPP のインストール: コントロールパネルを開く画面](https://make.wordpress.org/core/files/2013/03/installing-xampp-9.png)
+
+<!--
 ### 3\. Starting XAMPP
+-->
 
+### 3\. XAMPP の実行
+
+<!--
 The XAMPP Control Panel allows you to manually start and stop Apache and MySQL, or install them as services.
+-->
 
+XAMPP コントロールパネルでは、Apache と MySQL を手動で起動・停止したり、サービスとしてインストールしたりできます。
+
+<!--
 ![XAMPP Control Panel Screen](https://make.wordpress.org/core/files/2013/03/xampp-control-panel-1.png)
+-->
 
+![XAMPP コントロールパネル画面](https://make.wordpress.org/core/files/2013/03/xampp-control-panel-1.png)
+
+<!--
 To start Apache or MySQL manually, **click the Start button** under **Actions** next to that module.
+-->
 
+手動で Apache や MySQL を起動するには、そのモジュールの隣の**アクション**の下にある**スタートボタンをクリック**します。
+
+<!--
 ![Start XAMPP Modules Manually Screen](https://make.wordpress.org/core/files/2013/03/xampp-control-panel-2.png)
+-->
 
+![XAMPP モジュールを手動で起動する画面](https://make.wordpress.org/core/files/2013/03/xampp-control-panel-2.png)
+
+<!--
 Depending on your security settings, Windows 7 users will probably have a small window open, asking if you want to allow **xampp-control.exe** to make modifications to your computer. **Click Yes** to allow Apache or MySQL to start.
+-->
 
+セキュリティ設定にもよりますが、Windows 7の場合は小さなウィンドウが開き、**xampp-control.exe** がコンピューターに変更を加えることを許可するかどうか尋ねられるでしょう。**はいをクリック**すると、Apache または MySQL の起動が許可されます。
+
+<!--
 If you plan on using XAMPP frequently, you may want to consider installing Apache and MySQL as services on your computer. The advantage to this is that both modules will already be running once the XAMPP control panel opens.
+-->
 
+XAMPP を頻繁に使用する予定がある場合、Apache と MySQL をサービスとしてコンピューターにインストールすることを検討するとよいでしょう。この場合、XAMPP のコントロールパネルが開くと、両方のモジュールがすでに起動しているという利点があります。
+
+<!--
 To install Apache and MySQL as services, **click the red X** to the left of each module under **Services**. You will see a small window open, asking you to confirm that you want to install it as a service. **Click Yes** to complete the installation. Repeat for the other module.
+-->
 
+Apache と MySQL をサービスとしてインストールするには、**サービス**の下にある各モジュールの左側にある**赤い X をクリック**します。小さなウィンドウが開き、サービスとしてインストールするかどうかを確認するよう求められます。**はいをクリック**するとインストールが完了します。他のモジュールも同様に操作してください。
+
+<!--
 ![Installing Apache As A Service Screen](https://make.wordpress.org/core/files/2013/03/xampp-control-panel-3.png)
+-->
 
+![Apache をサービスとしてインストールする画面](https://make.wordpress.org/core/files/2013/03/xampp-control-panel-3.png)
+
+<!--
 Once again, you may have a security window open, asking if you want to allow the modifications to your computer. **Click Yes** to allow it.
+-->
 
+再度セキュリティウィンドウが開き、コンピューターへの変更を許可するかどうか尋ねられることがあります。**はいをクリック**して許可してください。
+
+<!--
 The **red X** will change to a **green check mark** once the service has been installed successfully.
+-->
 
+サービスが正常にインストールされると、**赤い X** が**緑のチェックマーク**に変化します。
+
+<!--
 **Important:** After the initial setup is complete, you will need to run XAMPP as an administrator on Windows 7 when you start the program again. To do that, **click Start**, find **XAMPP Control Panel** in your Programs list, then right-click and select **Run As Administrator**.
+-->
 
+**重要**: 初期設定が完了した後、Windows 7では、再度プログラムを起動する際に XAMPP を管理者として実行する必要があります。そのためには、**スタートをクリック**し、プログラムリストの中から **XAMPP コントロールパネル**を見つけ、右クリックして**管理者として実行**を選択してください。
+
+<!--
 ![Run XAMPP As Administrator](https://make.wordpress.org/core/files/2013/03/xampp-run-as-admin.png)
+-->
 
+![XAMPP を管理者として実行](https://make.wordpress.org/core/files/2013/03/xampp-run-as-admin.png)
+
+<!--
 ### 4\. Configuring XAMPP
+-->
 
+### 4\. XAMPP の設定
+
+<!--
 The default XAMPP install is already pre-configured to run a local web server comparable to most web hosting servers. However, there are a couple basic configuration changes you can make to increase your productivity.
+-->
 
+デフォルトの XAMPP は、ほとんどの Web ホスティングサーバーと同等のローカル Web サーバーを実行するようにあらかじめ設定されています。しかし、生産性を向上させるために、いくつかの基本的な設定変更を行うことができます。
+
+<!--
 The first change will be to set the default text editor. As you can see, XAMPP defaults to Notepad, the native Windows text editor. **Click the folder button** to the right to open the file explorer. Navigate to the folder for your favorite text editor, **select the .exe file**, then **click Open**.
+-->
 
+最初の変更は、デフォルトのテキストエディターを設定することです。ご覧のように、XAMPP のデフォルトは Windows のネイティブテキストエディターであるメモ帳です。右側の**フォルダーボタンをクリック**すると、ファイルエクスプローラが開きます。お気に入りのテキストエディターのフォルダーに移動し、**.exeファイルを選択**し、**開くをクリック**してください。
+
+<!--
 ![Configuring XAMPP: Set Default Text Editor Screen](https://make.wordpress.org/core/files/2013/03/configure-xampp-2.png)
+-->
 
+![XAMPP の設定: デフォルトのテキストエディターを設定する画面](https://make.wordpress.org/core/files/2013/03/configure-xampp-2.png)
+
+<!--
 The next change is to select your desired font for the logs that XAMPP creates. If you are trying to track down an issue, you will spend time reading different logs, so choose a font that is easy for you to read. Click on **Log Options**, then select your desired font and font size, then **click Save**.
+-->
 
+次の変更は、XAMPP が生成するログのフォントを希望のものに変更することです。問題を追跡しようとすると、さまざまなログを読むのに時間がかかるため、読みやすいフォントを選んでください。**ログのオプション**をクリックし、希望のフォントとフォントサイズを選択し、**保存をクリック**してください。
+
+<!--
 ![Configuring XAMPP: Set Default Font For Logs Screen](https://make.wordpress.org/core/files/2013/03/configure-xampp-3.png)
+-->
 
+![XAMPP の設定: ログのデフォルトフォントを設定する画面](https://make.wordpress.org/core/files/2013/03/configure-xampp-3.png)
+
+<!--
 After making those changes, **click Save** in the main configuration window.
+-->
 
+変更した後、メイン設定ウィンドウの**保存をクリック**してください。
+
+<!--
 ![Configuring XAMPP: Save Settings Screen](https://make.wordpress.org/core/files/2013/03/configure-xampp-4.png)
+-->
 
+![XAMPP の設定: 設定を保存する画面](https://make.wordpress.org/core/files/2013/03/configure-xampp-4.png)
+
+<!--
 If you find that you need to make a configuration change to Apache, PHP, or MySQL, **click the Config button** for that module to bring up a context menu with links to the config files for that module. The file will open in the default text editor you chose earlier.
+-->
 
+Apache、PHP、MySQL の設定を変更する必要がある場合、そのモジュールの**設定ボタンをクリック**すると、そのモジュールの設定ファイルへのリンクを含むコンテキストメニューが表示されます。ファイルは、先に選択したデフォルトのテキストエディターで開きます。
+
+<!--
 ![Configuring XAMPP: Advanced Settings Screen](https://make.wordpress.org/core/files/2013/03/configure-xampp-1.png)
+-->
 
+![XAMPP の設定: 詳細設定の画面](https://make.wordpress.org/core/files/2013/03/configure-xampp-1.png)
+
+<!--
 ### 5\. Securing Your XAMPP Install
+-->
 
+### 5\. XAMPP のインストールを保護する
+
+<!--
 Once the configuration is done, go to **http://localhost/** in your web browser. You will see the XAMPP splash screen first, asking you to select your language. The web-based XAMPP panel will then appear.
+-->
 
+設定が完了したら、Web ブラウザーで **http://localhost/** にアクセスしてください。最初に XAMPP のスプラッシュ画面が表示され、言語を選択するよう求められます。その後、Web ベースの XAMPP パネルが表示されます。
+
+<!--
 ![XAMPP Web Panel Welcome Screen](https://make.wordpress.org/core/files/2013/03/xampp-web-panel-welcome.png)
+-->
 
+![XAMPP の Web パネルのウェルカム画面](https://make.wordpress.org/core/files/2013/03/xampp-web-panel-welcome.png)
+
+<!--
 It is recommended that you secure your XAMPP install with a unique username and password for both the web panel and for phpMyAdmin.
+-->
 
+Web パネルと phpMyAdmin の両方に固有のユーザー名とパスワードを設定し、XAMPP を保護することをおすすめします。
+
+<!--
 Click the **Security** link in the left sidebar. The **XAMPP Security** screen will appear. A table will show you the current security status for each component.
+-->
 
+左サイドバーの「**セキュリティ**」リンクをクリックします。「**XAMPP のセキュリティ**」画面が表示されます。各コンポーネントの現在のセキュリティ状態が表で表示されます。
+
+<!--
 To secure the XAMPP panel and phpMyAdmin, click the **http://localhost/security/xamppsecurity.php** link to open the Security Console.
+-->
 
+XAMPP パネルと phpMyAdmin を保護するには、**http://localhost/security/xamppsecurity.php** リンクをクリックして「セキュリティコンソール」を開いてください。
+
+<!--
 ![XAMPP Security Console Screen](https://make.wordpress.org/core/files/2013/03/xampp-security-console.png)
+-->
 
+![XAMPP セキュリティコンソール画面](https://make.wordpress.org/core/files/2013/03/xampp-security-console.png)
+
+<!--
 The first section deals with the MySQL user. By default, the MySQL administrator (root) has no password in XAMPP. To secure MySQL, enter your desired password in the **New Password** field, then again in the **Repeat the new password** box. Choose your authentication method (http or cookie), then click **Password Changing**.
+-->
 
+最初のセクションでは、MySQL ユーザーについて説明します。デフォルトでは、XAMPP の MySQL 管理者 (root) にはパスワードがありません。MySQL を保護するために、**新しいパスワード**フィールドに希望のパスワードを入力し、**新しいパスワードの繰り返し**ボックスに再度パスワードを入力します。認証方法 (http または cookie) を選択し、**パスワードの変更**をクリックします。
+
+<!--
 The second section deals with securing the XAMPP web panel. Enter a unique username in the **Username** field, a strong password in the **Password** field, then **click Make safe the XAMPP directory**.
+-->
 
+2つ目のセクションは、XAMPP の Web パネルを保護するためのものです。**ユーザー名**フィールドにユニークなユーザー名を入力し、**パスワード**フィールドに強力なパスワードを入力し、**XAMPP のディレクトリを安全な状態にする**をクリックします。
+
+<!--
 Navigate to the XAMPP Security section to check the security status of each component after completing these steps. The XAMPP directory, MySQL, and phpMyAdmin should now have a **Secure** status next to them.
+-->
 
+これらのステップを完了した後、XAMPP のセキュリティセクションに移動し、各コンポーネントのセキュリティステータスを確認してください。XAMPP ディレクトリ、MySQL、phpMyAdmin の横に**安全**というステータスが表示されているはずです。
+
+<!--
 ![XAMPP Security Status Screen](https://make.wordpress.org/core/files/2013/03/xampp-security-status.png)
+-->
 
+![XAMPP セキュリティステータス画面](https://make.wordpress.org/core/files/2013/03/xampp-security-status.png)
+
+<!--
 ### 6\. Creating a MySQL Database With XAMPP
+-->
 
+### 6\. XAMPP で MySQL データベースを作成する
+
+<!--
 In XAMPP, a database is created and accessed via phpMyAdmin. You can access phpMyAdmin by entering **http://localhost/phpmyadmin/** in your web browser.
+-->
 
+XAMPP では、作成したデータベースは phpMyAdmin でアクセスします。phpMyAdmin には、Web ブラウザーで **http://localhost/phpmyadmin/** と入力することでアクセスできます。
+
+<!--
 The phpMyAdmin login screen will appear first. Select your language, then enter the username (root) and unique password you created for the MySQL user in the previous section.
+-->
 
+最初に phpMyAdmin のログイン画面が表示されます。言語を選択し、前のセクションで MySQL ユーザー用に作成したユーザー名 (root) とパスワードを入力します。
+
+<!--
 ![phpMyAdmin Login Screen](https://make.wordpress.org/core/files/2013/03/xampp-phpmyadmin-login.png)
+-->
 
+![phpMyAdmin のログイン画面](https://make.wordpress.org/core/files/2013/03/xampp-phpmyadmin-login.png)
+
+<!--
 The main phpMyAdmin screen will appear. On the left is a list of databases that already exist: **cdcol, information\_schema, mysql, performance\_schema, phpmyadmin, test,** and **webauth**. Do not delete these, as they are necessary for XAMPP and phpMyAdmin to run properly.
+-->
 
+phpMyAdmin のメイン画面が表示されます。左側には、すでに存在するデータベースのリストが表示されます。**cdcol、information_schema、 mysql、 performance_schema、phpmyadmin、test、webauth** です。これらは XAMPP と phpMyAdmin が正常に動作するために必要であるため、削除しないでください。
+
+<!--
 To create a database, **click Databases** in the top navbar.
+-->
 
+データベースを作成するには、トップナビゲーションバーの**データベースをクリック**します。
+
+<!--
 ![XAMPP: Navbar On phpMyAdmin Main Screen](https://make.wordpress.org/core/files/2013/06/database-create-phpmyadmin-navbar.png)
+-->
 
+![XAMPP phpMyAdmin メイン画面のナビゲーションバー](https://make.wordpress.org/core/files/2013/06/database-create-phpmyadmin-navbar.png)
+
+<!--
 On the screen that appears, you need to enter the database name (for example, **root\_wordpress-trunk**) in the left field, choose your database collation from the Collation dropdown box (**utf8\_unicode\_ci**), then **click Create**.
+-->
 
+表示された画面で、左側のフィールドにデータベース名 (例: **root_wordpress-trunk**) を入力し、ドロップダウンボックスからデータベースの照合を選択し (**utf8_unicode_ci**)、**作成をクリック**します。
+
+<!--
 ![XAMPP: Create Database In phpMyAdmin Screen](https://make.wordpress.org/core/files/2013/06/database-create-name-collation.png)
+-->
 
+![XAMPP: phpMyAdmin でのデータベースの作成](https://make.wordpress.org/core/files/2013/06/database-create-name-collation.png)
+
+<!--
 You will see a success message once the database has been created.
+-->
 
+データベースが作成されると、成功のメッセージが表示されます。
+
+<!--
 ![XAMPP: Database Creation Success Message Screen](https://make.wordpress.org/core/files/2013/06/database-create-success-message.png)
+-->
 
+![XAMPP: データベース作成が成功したメッセージが表示される画面](https://make.wordpress.org/core/files/2013/06/database-create-success-message.png)
+
+<!--
 The default phpMyAdmin user, **root**, is automatically assigned to the database upon creation, and has the unique password you created in the previous step. The database connection info you will need to use when installing WordPress locally is:
+-->
+
+デフォルトの phpMyAdmin ユーザーである **root** は、データベースの作成時に自動的に割り当てられ、前のステップで作成した固有のパスワードを持っています。WordPress をローカルにインストールする際に必要なデータベース接続情報は以下の通りです。
 
 ```php
 /** The name of the database for WordPress */
@@ -162,17 +462,46 @@ define('DB_PASSWORD', 'yourmysqlpassword');
 define('DB_HOST', 'localhost');
 ```
 
+<!--
 ### 7\. Shutting Down XAMPP
+-->
 
+### 7\. XAMPP のシャットダウン
+
+<!--
 You can shut down XAMPP from the main control panel by **clicking Stop** next to each of the services that are running, then **click Quit**.
+-->
 
+メインコントロールパネルから XAMPP をシャットダウンするには、実行中の各サービスの横にある**停止をクリック**し、次に**終了をクリック**してください。
+
+<!--
 ![XAMPP Shutdown: Control Panel Screen](https://make.wordpress.org/core/files/2013/03/stopping-xampp-1.png)
+-->
 
+![XAMPP のシャットダウン: コントロールパネル画面](https://make.wordpress.org/core/files/2013/03/stopping-xampp-1.png)
+
+<!--
 **Helpful tip:** You can also shut down XAMPP from the systray icon. **Right-click the XAMPP icon**, and a context menu will appear. Hover over the first service running, then **click Stop**. The green light will turn red once it has stopped. Repeat for the other services running, then **click Quit** to exit the program.
+-->
 
+**Helpful tip:** システムトレイのアイコンからも XAMPP をシャットダウンできます。**XAMPP のアイコンを右クリック**すると、コンテキストメニューが表示されます。最初に起動しているサービスにカーソルを合わせ、**停止をクリック**してください。停止すると、緑のランプが赤に変わります。他のサービスも同様に実行し、**終了をクリック**してプログラムを終了してください。
+
+<!--
 ![XAMPP Shutdown: Context Menu Screen](https://make.wordpress.org/core/files/2013/03/stopping-xampp-2.png)
+-->
 
+![XAMPP のシャットダウン: コンテキストメニュー画面](https://make.wordpress.org/core/files/2013/03/stopping-xampp-2.png)
+
+<!--
 ## Next Steps
+-->
 
+## 次のステップ
+
+<!--
 *   [Installing WordPress From A Zip File](https://make.wordpress.org/core/handbook/installing-wordpress-locally/installing-from-a-zip-file/)
 *   [Installing WordPress Via SVN](https://make.wordpress.org/core/handbook/installing-wordpress-locally/installing-via-svn/)
+-->
+
+*   [Zip ファイルからのインストール](https://make.wordpress.org/core/handbook/installing-wordpress-locally/installing-from-a-zip-file/)
+*   [SVN を使ってのインストール](https://make.wordpress.org/core/handbook/installing-wordpress-locally/installing-via-svn/)


### PR DESCRIPTION
Closes #93
日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/translate/tutorials-installing-a-local-server-xampp/core/tutorials/installing-a-local-server/xampp.md
英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/tutorials/installing-a-local-server/xampp.md
英語 Web ページ: https://make.wordpress.org/core/handbook/tutorials/installing-a-local-server/xampp/