### PR TITLE
translate/tutorials/installing-a-local-server/wampserver.md

### DIFF
--- a/core/tutorials/installing-a-local-server/wampserver.md
+++ b/core/tutorials/installing-a-local-server/wampserver.md
@@ -1,140 +1,391 @@
+<!--
 # Installing WampServer
+-->
 
+# WampServer のインストール
+
+<!--
 ## Overview
+-->
 
+## 概要
+
+<!--
 [WampServer](http://www.wampserver.com/en/) is a local server package for Windows, allowing you to install and host web applications that use Apache, PHP and MySQL.
+-->
 
+[WampServer](http://www.wampserver.com/en/) は、Windows 用のローカルサーバーパッケージで、Apache、PHP、MySQL を使用する Web アプリケーションのインストールとホスティングが可能です。
+
+<!--
 This article will walk you through the steps to install WampServer on your computer.
+-->
 
+この記事では、WampServer をコンピューターにインストールする手順を説明します。
+
+<!--
 ## Installing WampServer
+-->
 
+## WampServer のインストール
+
+<!--
 ### 1\. Downloading WampServer
+-->
 
+### 1\. WampServer のダウンロード
+
+<!--
 Download the installer file for the [latest version of WampServer](http://www.wampserver.com/en/#download-wrapper), and save the file to your computer.
+-->
 
+[WampServer の最新版](http://www.wampserver.com/en/#download-wrapper)のインストーラファイルをダウンロードし、コンピューターに保存してください。
+
+<!--
 ![Download WampServer Screen](https://make.wordpress.org/core/files/2013/06/download-wampserver.png)
+-->
 
+![WampServer ダウンロードの画面](https://make.wordpress.org/core/files/2013/06/download-wampserver.png)
+
+<!--
 Make sure you select the correct installer file for your version of Windows. If you don’t know if your system is 32-bit or 64-bit, **right-click on My Computer**, and then **click Properties**.
+-->
 
+お使いの Windows のバージョンに合ったインストーラファイルを選択してください。お使いのシステムが32ビットか64ビットかわからない場合は、**マイコンピュータを右クリック**し、**プロパティをクリック**してください。
+
+<!--
 ![Windows 7 System Type Settings](https://make.wordpress.org/core/files/2013/06/windows7-system-type-64x.png)
+-->
 
+![Windows 7 のシステムの種類](https://make.wordpress.org/core/files/2013/06/windows7-system-type-64x.png)
+
+<!--
 *   For Vista, Windows 7, and Windows 8, look for **System Type**.
 *   For Windows XP, look for **x64** in the **System description**.
+-->
 
+*   Vista、Windows 7、Windows 8の場合は、**システムの種類**を探します。
+*   Windows XP の場合は、**システムの種類**の中に **x64** が含まれていることを確認してください。
+
+<!--
 ### 2\. Installing WampServer
+-->
 
+### 2\. WampServer のインストール
+
+<!--
 To start the installation process, you need to open the folder where you saved the file, and **double-click the installer file**. A security warning window will open, asking if you are sure you want to run this file. **Click Run** to start the installation process.
+-->
 
+インストールを開始するには、ファイルを保存したフォルダーを開き、**インストーラファイルをダブルクリック**します。セキュリティ警告ウィンドウが開き、このファイルを実行してもよいかどうか尋ねられます。**実行をクリック**すると、インストールが開始されます。
+
+<!--
 Next you will see the Welcome To The WampServer Setup Wizard screen. **Click Next** to continue the installation.
+-->
 
+次に、「WampServer セットアップウィザードへようこそ」画面が表示されます。**次へをクリック**してインストールを続行します。
+
+<!--
 ![Welcome To The WampServer Setup Wizard Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-2.png)
+-->
 
+![「WampServer セットアップウィザードへようこそ」画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-2.png)
+
+<!--
 The next screen you are presented with is the License Agreement. Read the agreement, check the radio button next to **I accept the agreement**, then **click Next** to continue the installation.
+-->
 
+次に表示される画面は、使用許諾契約書です。使用許諾契約書を読み、**使用許諾契約書に承諾する**のラジオボタンにチェックを入れ、**次へをクリック**してインストールを続行します。
+
+<!--
 ![Installing WampServer: License Agreement Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-3.png)
+-->
 
+![WampServer のインストール: 使用許諾契約画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-3.png)
+
+<!--
 Next you will see the Select Destination Location screen. Unless you would like to install WampServer on another drive, you should not need to change anything. **Click Next** to continue.
+-->
 
+次に、「インストール先の選択」画面が表示されます。WampServer を他のドライブにインストールしたいのでなければ、何も変更する必要はありません。**次へをクリック**してください。
+
+<!--
 ![Installing WampServer: Choose Install Location Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-4.png)
+-->
 
+![WampServer のインストール: 「インストール先の選択」画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-4.png)
+
+<!--
 The next screen you are presented with is the Select Additional Tasks screen. You will be able to select whether you would like a Quick Launch icon added to the taskbar or a Desktop icon created once installation is complete. Make your selections, then **click Next** to continue.
+-->
 
+次に表示されるのは、「追加タスクの選択」画面です。インストールが完了したら、タスクバーにクイック起動アイコンを追加するか、デスクトップ用アイコンを作成するかを選択できます。選択した後、**次へをクリック**し、次に進みます。
+
+<!--
 ![Installing WampServer: Select Additional Tasks Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-5.png)
+-->
 
+![WampServer のインストール: 「追加タスクの選択」画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-5.png)
+
+<!--
 Next you will see the Ready To Install screen. You can review your setup choices, and change any of them by **clicking Back** to the appropriate screen, if you choose to. Once you have reviewed your choices, **click Install** to continue.
+-->
 
+次に、「インストール準備完了」画面が表示されます。設定した内容を確認し、変更したい場合は、**戻るをクリック**して適切な画面に戻ってください。選択した内容を確認したら、**インストールをクリック**し、続行します。
+
+<!--
 ![Installing WampServer: Ready To Install Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-6.png)
+-->
 
+![WampServer のインストール: 「インストール準備完了」画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-6.png)
+
+<!--
 WampServer will begin extracting files to the location you selected.
+-->
 
+WampServer は、選択した場所にファイルの展開を開始します。
+
+<!--
 ![Installing WampServer: Unpacking Files Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-7.png)
+-->
 
+![WampServer のインストール: ファイル解凍の画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-7.png)
+
+<!--
 Once the files are extracted, you will be asked to select your default browser. WampServer defaults to Internet Explorer upon opening the local file browser window. If your default browser isn’t IE, then look in the following locations for the corresponding .exe file:
+-->
+
+ファイルが解凍されると、デフォルトのブラウザーを選択するように求められます。WampServer は、ローカルファイルをブラウザーウィンドウを開くときに、デフォルトで Internet Explorer を使用します。デフォルトのブラウザーが IE でない場合、以下の場所で対応する .exe ファイルを探してください。
 
 *   **Opera:** C:\\Program Files (x86)\\Opera\\opera.exe
 *   **Firefox:** C:\\Program Files (x86)\\Mozille Firefox\\firefox.exe
 *   **Safari:** C:\\Program Files (x86)\\Safari\\safari.exe
 *   **Chrome:** C:\\Users\\xxxxx\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe
 
+<!--
 Select your default browser’s .exe file, then **click Open** to continue.
+-->
 
+デフォルトのブラウザーの .exe ファイルを選択し、**開くをクリック**して続行します。
+
+<!--
 ![Installing WampServer: Choose Default Browser Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-8.png)
+-->
 
+![WampServer のインストール: デフォルトブラウザーを選択する画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-8.png)
+
+<!--
 A Windows Security Alert window will open, saying that Windows Firewall has blocked some features of the program. Check whether you want to allow Apache HTTP Server to communicate on a private or public network, then **click Allow Access**.
+-->
 
+Windows セキュリティ警告ウィンドウが開き、Windows ファイアウォールによってプログラムの一部の機能がブロックされていることが表示されます。Apache HTTP Server がプライベートまたはパブリックネットワークで通信することを許可するかどうかを確認し、**アクセスを許可するをクリック**します。
+
+<!--
 The Setup screen will appear next, showing you the status of the installation process.
+-->
 
+次に、セットアップ画面が表示され、インストール作業の状況が表示されます。
+
+<!--
 ![Installing WampServer: Finishing Installation Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-10.png)
+-->
 
+![WampServer のインストール: インストールを終了する画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-10.png)
+
+<!--
 Once the progress bar is completely green, the PHP Mail Parameters screen will appear. Leave the SMTP server as **localhost**, and change the email address to one of your choosing. **Click Next** to continue.
+-->
 
+プログレスバーが完全に緑色になったら、「PHP メールパラメータ」画面が表示されます。SMTP サーバーは **localhost** のまま、メールアドレスは任意のものに変更してください。**次へをクリック**して続行します。
+
+<!--
 ![Installing WampServer: PHP Mail Parameters Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-11.png)
+-->
 
+![WampServer のインストール: 「PHP メールパラメータ」画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-11.png)
+
+<!--
 The Installation Complete screen will now appear. **Check the Launch WampServer Now** box, then **click Finish** to complete the installation.
+-->
 
+インストール完了画面が表示されます。**WampServer を起動にチェックを入れ**、**終了をクリック**してインストールを完了します。
+
+<!--
 ![Installing WampServer: Completing The WampServer Setup Wizard Screen](https://make.wordpress.org/core/files/2013/06/installing-wamp-12.png)
+-->
 
+![WampServer のインストール: WampServer セットアップウィザードの完了画面](https://make.wordpress.org/core/files/2013/06/installing-wamp-12.png)
+
+<!--
 You should see the WampServer icon appear in the systray on the right side of your taskbar. If the icon is green, then everything is working properly. If the icon is orange, then there are issues with one of the services. If the icon is red, then both Apache and MySQL services aren’t running. You will need to resolve those issues before continuing.
+-->
 
+タスクバーの右側にあるシステムトレイに WampServer のアイコンが表示されるはずです。アイコンが緑色であれば、すべてが正常に動作しています。アイコンがオレンジ色の場合は、いずれかのサービスに問題があることを示しています。アイコンが赤色の場合は、Apache と MySQL の両方のサービスが実行されていないことを意味します。続行する前に、これらの問題を解決する必要があります。
+
+<!--
 ![WampServer: Server Status Screen](https://make.wordpress.org/core/files/2013/06/wampserver-server-status.png)
+-->
 
+![WampServer: サーバーステータスの画面](https://make.wordpress.org/core/files/2013/06/wampserver-server-status.png)
+
+<!--
 ### 3\. Testing WampServer
+-->
 
+### 3\. WampServer のテスト
+
+<!--
 Once you have completed the installation process, test that your installation is working properly by going to [http://localhost/](http://localhost/) in your browser. You should see the WampServer homepage displayed.
+-->
 
+インストールが完了したら、ブラウザーで [http://localhost/](http://localhost/) にアクセスし、インストールが正しく機能していることをテストしてください。WampServer のホームページが表示されるはずです。
+
+<!--
 ![WampServer Homepage Screen](https://make.wordpress.org/core/files/2013/06/wampserver-homepage.png)
+-->
 
+![WampServer のホームページ画面](https://make.wordpress.org/core/files/2013/06/wampserver-homepage.png)
+
+<!--
 If the WampServer homepage does not display, you will want to check that your [hosts file](http://en.wikipedia.org/wiki/Hosts_(file)) has **localhost mapped to 127.0.0.1**, and you aren’t running any other services on port 80, such as another local server (XAMPP, DesktopServer, etc.), WebDAV, or Skype.
+-->
 
+WampServer のホームページが表示されない場合は、[hosts ファイル](http://en.wikipedia.org/wiki/Hosts_(file))で **localhost が127.0.0.1にマッピングされているか**、他のローカルサーバー (XAMPP、DesktopServer など)、WebDAV、Skype などがポート80で他のサービスを実行していないかを確認してください。
+
+<!--
 You also need to check that phpMyAdmin is working by going to [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/) in your browser. If you get the **Cannot connect: invalid settings** error message, then you’ll need to edit the **C:\\wamp\\apps\\phpmyadmin3.5.1\\config.inc.php** file in a plain text editor (your version number may be different), and ensure this option is set to **true**:
+-->
+
+また、ブラウザーで [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/) にアクセスし、phpMyAdmin が動作していることを確認する必要があります。もし、**接続できません。設定が無効です。**というエラーメッセージが表示されたら、プレーンテキストエディターで **C:\\u0026\\apps\\phpmyadmin3.5.1\\config.inc.php** ファイルを編集し (バージョン番号は異なる場合があります)、このオプションを **true** に設定していることを確認する必要があります。
 
 ```php
-$cfg['Servers'][$i]['AllowNoPassword'] = true;```
+$cfg['Servers'][$i]['AllowNoPassword'] = true;
+```
 
+<!--
 ### 4\. Configuring WampServer
+-->
 
+### 4\. WampServer の設定
+
+<!--
 After you’ve installed and tested WampServer, you will need to adjust some configuration options to complete your local setup.
+-->
 
+WampServer のインストールとテストが完了したら、いくつかの設定オプションを調整してローカルセットアップを完了する必要があります。
+
+<!--
 #### 4.1 PHP Configuration
+-->
+
+#### 4.1 PHP の設定
 
 Click on the WampServer icon, go to the **php menu**, and **click on the php.ini** option. This will open the **php.ini** file in your plain text editor. Adjust the following settings:
 
-*   Set level of error reporting – remove the `;` at beginning of line to enable:  
+WampServer のアイコンをクリックし、**php メニュー**に移動し、**php.ini オプションをクリック**します。これにより、プレーンテキストエディターで **php.ini** ファイルを開くことができます。以下の設定を調整してください。
+
+<!--
+*   Set level of error reporting – remove the `;` at beginning of line to enable:
     `error_reporting = E_ALL ^ E_DEPRECATED` (~line 112)
-*   Log PHP errors – remove the `;` at beginning of line to enable:  
+*   Log PHP errors – remove the `;` at beginning of line to enable:
     `error_log = "c:/wamp/logs/php_error.log"` (~line 639)
-*   Increase maximum size of POST data that PHP will accept – change the value:  
+*   Increase maximum size of POST data that PHP will accept – change the value:
     `post_max_size = 50M` (~line 734)
-*   Increase maximum allowed size for uploaded files – change the value:  
+*   Increase maximum allowed size for uploaded files – change the value:
     `upload_max_filesize = 50M` (~line 886)
+-->
 
+*   エラーレポートのレベルを設定する - 行頭の `;` を削除することで有効になります:
+    `error_reporting = E_ALL ^ E_DEPRECATED` (112行目)
+*   PHP エラーのログを取得する – 行頭の `;` を削除することで有効になります:
+    `error_log = "c:/wamp/logs/php_error.log"` (639行目)
+*   PHP が許可する POST データの最大サイズを増やす – 次の値を変更します:
+    `post_max_size = 50M` (734行目)
+*   アップロードファイルの最大サイズを増やす – 次の値を変更します:
+    `upload_max_filesize = 50M` (886行目)
+
+<!--
 Once you have made the above changes, **click Save**.
+-->
 
+上記の変更を行ったら、**保存をクリック**します。
+
+<!--
 #### 4.2 Apache Configuration
+-->
 
+#### 4.2 Apache の設定
+
+<!--
 To use custom permalinks in WordPress, you will need to enable Apache’s `rewrite_module`. **Click on the WampServer icon**, go to the **Apache > Apache modules** menu, then find and **click rewrite\_module** to ensure it is enabled. WampServer will change the **httpd.conf** file, and restart Apache automatically.
+-->
 
+WordPress でカスタムパーマリンクを使用するには、Apache の `rewrite_module` を有効にする必要があります。**WampServer アイコンをクリック**し、**Apache > Apache モジュール**メニューに移動し、**rewrite_module** をクリックし、それが有効になっていることを確認します。WampServer は **httpd.conf** ファイルを変更し、Apache を自動的に再起動します。
+
+<!--
 ![Enable rewrite_module Apache Module Screen](https://make.wordpress.org/core/files/2013/06/wampserver-enable-rewrite-module.png)
+-->
 
+![rewrite_module Apache mジュールを有効化する画面](https://make.wordpress.org/core/files/2013/06/wampserver-enable-rewrite-module.png)
+
+<!--
 ### 5\. Creating A MySQL Database With WampServer
+-->
 
+### 5\. WampServer で MySQL データベースを作成する
+
+<!--
 Creating a database in WampServer is done via phpMyAdmin. You can access phpMyAdmin by entering [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/) in your web browser.
+-->
 
+WampServer のデータベースの作成は、phpMyAdmin で行います。Web ブラウザーで [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/) と入力すると、phpMyAdmin にアクセスできます。
+
+<!--
 The main phpMyAdmin screen will appear. On the left is a list of databases that already exist: **information\_schema**, **mysql**, **performance\_schema**, and **test**. Do not delete these, as they are necessary for WampServer and phpMyAdmin to run properly.
+-->
 
+phpMyAdmin のメイン画面が表示されます。左側には、すでに存在するデータベースのリストが表示されます。**cdcol、information_schema、 mysql、 performance_schema、phpmyadmin、test、webauth** です。これらは XAMPP と phpMyAdmin が正常に動作するために必要であるため、削除しないでください。
+
+<!--
 To create a database, **click Databases** in the main navbar at the top.
+-->
 
+データベースを作成するには、トップナビゲーションバーの**データベースをクリック**します。
+
+<!--
 ![WampServer Navbar On phpMyAdmin Main Screen](https://make.wordpress.org/core/files/2013/06/database-create-phpmyadmin-navbar.png)
+-->
 
+![WampServer phpMyAdmin メイン画面のナビゲーションバー](https://make.wordpress.org/core/files/2013/06/database-create-phpmyadmin-navbar.png)
+
+<!--
 On the Databases screen, you will need to enter the database name (for example, **root\_wordpress-trunk**) in the left field, choose your database collation from the Collation dropdown box (**utf8\_unicode\_ci**), then **click Create**.
+-->
 
+表示された画面で、左側のフィールドにデータベース名 (例: **root_wordpress-trunk**) を入力し、ドロップダウンボックスからデータベースの照合を選択し (**utf8_unicode_ci**)、**作成をクリック**します。
+
+<!--
 ![WampServer Create Database In phpMyAdmin Screen](https://make.wordpress.org/core/files/2013/06/database-create-name-collation.png)
+-->
 
+![WampServer phpMyAdmin でのデータベースの作成](https://make.wordpress.org/core/files/2013/06/database-create-name-collation.png)
+
+<!--
 You will see a success message once the database has been created, and your new database will appear in the list on the left.
+-->
 
+データベースが作成されると成功のメッセージが表示され、新しいデータベースが左のリストに表示されます。
+
+<!--
 ![WampServer Database Creation Success Message Screen](https://make.wordpress.org/core/files/2013/06/database-create-success-message.png)
+-->
 
+![WampServer データベース作成が成功したメッセージが表示される画面](https://make.wordpress.org/core/files/2013/06/database-create-success-message.png)
+
+<!--
 The default phpMyAdmin user, **root**, is automatically assigned to the database upon creation, and has no password. The database connection info you will need to use when installing WordPress locally will be:
+-->
+
+デフォルトの phpMyAdmin ユーザーである **root** は、データベースの作成時に自動的に割り当てられ、パスワードを持っていません。WordPress をローカルにインストールする際に必要なデータベース接続情報は以下の通りです。
 
 ```php
 /** The name of the database for WordPress */
@@ -150,17 +401,46 @@ define('DB_PASSWORD', '');
 define('DB_HOST', 'localhost');
 ```
 
+<!--
 ### 6\. Shutting Down WampServer
+-->
 
+### 6\. WampServer のシャットダウン
+
+<!--
 To shut down WampServer, **click on the systray icon** and **select Stop All Services** to shut down the Apache and MySQL services. The icon will turn red once all services have been shut down.
+-->
 
+WampServer をシャットダウンするには、**シストレイアイコンをクリック**し、**すべてのサービスを停止を選択**し、Apache と MySQL のサービスをシャットダウンしてください。すべてのサービスが停止すると、アイコンが赤くなります。
+
+<!--
 ![WampServer: Stop All Services Screen](https://make.wordpress.org/core/files/2013/06/shutdown-wamp-1.png)
+-->
 
+![WampServer: すべてのサービスを停止する画面](https://make.wordpress.org/core/files/2013/06/shutdown-wamp-1.png)
+
+<!--
 Next you will **right-click on the WampServer systray icon** and **click Exit** to close the program.
+-->
 
+次に、**WampServer のシステムトレイアイコンを右クリック**し、**終了をクリック**してプログラムを終了します。
+
+<!--
 ![WampServer: Exit Program Screen](https://make.wordpress.org/core/files/2013/06/shutdown-wamp-2.png)
+-->
 
+![WampServer: プログラムを終了する画面](https://make.wordpress.org/core/files/2013/06/shutdown-wamp-2.png)
+
+<!--
 ## Next Steps
+-->
 
+## 次のステップ
+
+<!--
 *   [Installing WordPress From A Zip File](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-zip/)
 *   [Installing WordPress Via SVN](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-svn/)
+-->
+
+*   [Zip ファイルからのインストール](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-zip/)
+*   [SVN を使ってのインストール](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-svn/)

--- a/core/tutorials/installing-a-local-server/wampserver.md
+++ b/core/tutorials/installing-a-local-server/wampserver.md
@@ -255,7 +255,7 @@ WampServer のホームページが表示されない場合は、[hosts ファ�
 You also need to check that phpMyAdmin is working by going to [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/) in your browser. If you get the **Cannot connect: invalid settings** error message, then you’ll need to edit the **C:\\wamp\\apps\\phpmyadmin3.5.1\\config.inc.php** file in a plain text editor (your version number may be different), and ensure this option is set to **true**:
 -->
 
-また、ブラウザーで [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/) にアクセスし、phpMyAdmin が動作していることを確認する必要があります。もし、**接続できません。設定が無効です。**というエラーメッセージが表示されたら、プレーンテキストエディターで **C:\\u0026\\apps\\phpmyadmin3.5.1\\config.inc.php** ファイルを編集し (バージョン番号は異なる場合があります)、このオプションを **true** に設定していることを確認する必要があります。
+また、ブラウザーで [http://localhost/phpmyadmin/](http://localhost/phpmyadmin/) にアクセスし、phpMyAdmin が動作していることを確認する必要があります。もし、**接続できません。設定が無効です。** というエラーメッセージが表示されたら、プレーンテキストエディターで **C:\\u0026\\apps\\phpmyadmin3.5.1\\config.inc.php** ファイルを編集し (バージョン番号は異なる場合があります)、このオプションを **true** に設定していることを確認する必要があります。
 
 ```php
 $cfg['Servers'][$i]['AllowNoPassword'] = true;


### PR DESCRIPTION
Closes #92
日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/transpate/tutorials-installing-a-local-server-wampserver/core/tutorials/installing-a-local-server/wampserver.md
英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/tutorials/installing-a-local-server/wampserver.md
英語 Web ページ: https://make.wordpress.org/core/handbook/tutorials/installing-a-local-server/wampserver/