### PR TITLE
translate/references/keeping-up-with-gutenberg-index/*.md

### DIFF
--- a/core/references/keeping-up-with-gutenberg-index.md
+++ b/core/references/keeping-up-with-gutenberg-index.md
@@ -1,12 +1,30 @@
+<!--
 # Keeping up with Gutenberg: Index 2023
+-->
 
+# Gutenberg をキャッチアップする: インデックス 2023
+
+<!--
 **Previous years: **[2020](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020/) | [2021](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021/)** | **[2022](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022/)****
+-->
 
+**過去のインデックス: **[2020](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020/) | [2021](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021/)** | **[2022](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022/)****
+
+<!--
 This page is the one place you can bookmark for Gutenberg\-related team posts of Core, Core-Editor, Core-js, Core-css, Design, Meta, and Themes, and other teams, when relevant. It’s a chronological listing, not topical. Latest on top.
+-->
 
+このページは、Core、Core-Editor、Core-js、Core-css、Design、Meta、Themes の Gutenberg 関連チームの投稿を、ブックマークできるようにするためのものです。時系列順で掲載されており、トピックスではありません。最新のものから並んでいます。
+
+<!--
 *   See *[Explanations](https://make.wordpress.org/core/wp-admin/post.php?post=101683&action=edit#explanations)* on the bottom.
 *   Discussions are in the **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack channel and development happens in the [Gutenberg GitHub repository](https://github.com/WordPress/gutenberg/issues)
 *   Gutenberg [Versions in WordPress](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/) Core
+-->
+
+*   下部の「[説明](https://make.wordpress.org/core/wp-admin/post.php?post=101683&action=edit#explanations)」をご覧ください。
+*   議論は **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack チャンネルで、開発は [Gutenberg GitHub リポジトリ](https://github.com/WordPress/gutenberg/issues) で行われています。
+*   [WordPress コアにおける Gutenberg のバージョン](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/)
 
 * * *
 
@@ -124,12 +142,21 @@ This page is the one place you can bookmark for Gutenberg\-related team posts of
 
 2023-01-02 **[#core](https://make.wordpress.org/core/tag/core/)** The [Keeping up with Gutenberg Index 2022](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022/) is now a child page of this year. (u)
 
+<!--
 **Happy New Year!** 🎆 🙌 🎉🥂 *Welcome to the 4th year of Gutenberg Index.*
+-->
+
+**ハッピーニューイヤー !** 🎆 🙌🎉🥂 Gutenberg インデックスの4年目へようこそ。
 
 * * *
 
+<!--
 **Explanations**
+-->
 
+**説明**
+
+<!--
 *   **[#team](https://make.wordpress.org/core/tag/team/)** identifies a team’s WordPress Slack channel. [Join the Slack space](https://chat.wordpress.org/).
 *   (m) = Meeting Summaries/Notes, [check here for meeting days and times](http://make.wordpresss.org/meetings)
 *   (r) = general resource
@@ -137,9 +164,30 @@ This page is the one place you can bookmark for Gutenberg\-related team posts of
 *   We use universal date format in yyyy-mm-dd to indicate publication date.
 *   Separators divide the list by weeks
 *   *This page started in January 2021. The index started in July 2020*
+-->
 
+*   **[#team](https://make.wordpress.org/core/tag/team/)** は、チームの WordPress Slack チャンネルを特定します。[Slack スペースに参加する](https://chat.wordpress.org/)。
+*   (m) = ミーティングサマリーやノート。[ミーティング日時はこちらでご確認ください](http://make.wordpresss.org/meetings)。
+*   (r) = 一般的なリソース
+*   (u) = ソフトウェア、方法、プロセス、または議論の更新を示します
+*   投稿日を示すために、yyyy-mm-dd の世界共通の日付形式を使用しています。
+*   セパレーターでリストを週ごとに分割しています。
+*   このページは2021年1月にスタートしました。インデックスは2020年7月より開始しました。
+
+<!--
 Big thanks to Anne McCarthy @annezazu and William Patton @williampatton for support and review.
+-->
 
+Anne McCarthy @annezazu と William Patton @williampatton のサポートとレビューに感謝します。
+
+<!--
 If you find a post missing or you would like to help with this effort, ping Birgit Pauli-Haack (@bph) on Slack with the link and she will add it as soon as possible.
+-->
 
+もし、投稿がないのを見つけたり、この取り組みに協力したい場合は、Slack の Birgit Pauli-Haack (@bph) に連絡していただければ、できるだけ早く追加します。
+
+<!--
 Featured Image: Photo by [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
+-->
+
+アイキャッチ画像: [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) の [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) による写真

--- a/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020.md
+++ b/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020.md
@@ -1,16 +1,40 @@
+<!--
 # Gutenberg Index 2020
+-->
 
+# Gutenberg インデックス 2020
+
+<!--
 This page is the one place you can bookmark for Gutenberg\-related team posts of Core, Core-Editor, Core-js, Core-css, Design, Meta, and Themes, and other teams, when relevant. It’s a chronological listing, not topical. Latest on top.
+-->
 
+このページは、Core、Core-Editor、Core-js、Core-css、Design、Meta、Themes の Gutenberg 関連チームの投稿を、ブックマークできるようにするためのものです。時系列順で掲載されており、トピックスではありません。最新のものから並んでいます。
+
+<!--
 Discussions are in the **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack channel and development happens in the [Gutenberg GitHub repository](https://github.com/WordPress/gutenberg/issues).
+-->
 
+議論は **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack チャンネルで、開発は [Gutenberg GitHub リポジトリ](https://github.com/WordPress/gutenberg/issues) で行われています。
+
+<!--
 See *[Explanations](#explanations)* on the bottom.
+-->
 
+下部の「[説明](#explanations)」をご覧ください。
+
+<!--
 [2021 Index](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index-2021)
+-->
 
+[2021 インデックス](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index-2021)
+
+<!--
 [2022 Index](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/)
+-->
 
-[June](#2020-06) | [July](#july2020) | [August](#august2020) | [September](#september2020)  
+[2022 インデックス](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/)
+
+[June](#2020-06) | [July](#july2020) | [August](#august2020) | [September](#september2020)
 [October](#october2020) |[November](#november2020) | [December](#december2020)
 
 ## December 2020
@@ -517,8 +541,13 @@ See *[Explanations](#explanations)* on the bottom.
 
 * * *
 
-## Explanations
+<!--
+**Explanations**
+-->
 
+**説明**
+
+<!--
 *   **[#team](https://make.wordpress.org/core/tag/team/)** identifies a team’s WordPress Slack channel. [Join the Slack space](https://chat.wordpress.org/).
 *   (m) = Meeting Summaries/Notes, [check here for meeting days and times](http://make.wordpresss.org/meetings)
 *   (r) = general resource
@@ -526,9 +555,30 @@ See *[Explanations](#explanations)* on the bottom.
 *   We use universal date format in yyyy-mm-dd to indicate publication date.
 *   Separators divide the list by weeks
 *   This page started in July 2020.
+-->
 
+*   **[#team](https://make.wordpress.org/core/tag/team/)** は、チームの WordPress Slack チャンネルを特定します。[Slack スペースに参加する](https://chat.wordpress.org/)。
+*   (m) = ミーティングサマリーやノート。[ミーティング日時はこちらでご確認ください](http://make.wordpresss.org/meetings)。
+*   (r) = 一般的なリソース
+*   (u) = ソフトウェア、方法、プロセス、または議論の更新を示します
+*   投稿日を示すために、yyyy-mm-dd の世界共通の日付形式を使用しています。
+*   セパレーターでリストを週ごとに分割しています。
+*   このページは2020年7月にスタートしました。
+
+<!--
 Big thanks to Anne McCarthy @annezazu and William Patton @williampatton for support and review.
+-->
 
+Anne McCarthy @annezazu と William Patton @williampatton のサポートとレビューに感謝します。
+
+<!--
 If you find a post missing or you would like to help with this effort, ping Birgit Pauli-Haack (@bph) on Slack with the link and she will add it as soon as possible.
+-->
 
+もし、投稿がないのを見つけたり、この取り組みに協力したい場合は、Slack の Birgit Pauli-Haack (@bph) に連絡していただければ、できるだけ早く追加します。
+
+<!--
 Featured Image: Photo by [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
+-->
+
+アイキャッチ画像: [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) の [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) による写真

--- a/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021.md
+++ b/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021.md
@@ -1,22 +1,58 @@
+<!--
 # Gutenberg Index 2021
+-->
 
+# Gutenberg インデックス 2021
+
+<!--
 This page is the one place you can bookmark for Gutenberg\-related team posts of Core, Core-Editor, Core-js, Core-css, Design, Meta, and Themes, and other teams, when relevant. It’s a chronological listing, not topical. Latest on top.
+-->
 
+このページは、Core、Core-Editor、Core-js、Core-css、Design、Meta、Themes の Gutenberg 関連チームの投稿を、ブックマークできるようにするためのものです。時系列順で掲載されており、トピックスではありません。最新のものから並んでいます。
+
+<!--
 Discussions are in the **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack channel and development happens in the [Gutenberg GitHub repository](https://github.com/WordPress/gutenberg/issues).
+-->
 
+議論は **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack チャンネルで、開発は [Gutenberg GitHub リポジトリ](https://github.com/WordPress/gutenberg/issues) で行われています。
+
+<!--
 See *[Explanations](#explanations)* on the bottom.
+-->
+
+下部の「[説明](#explanations)」をご覧ください。
 
 * * *
 
+<!--
 [**WordPress 5.9 Development Cycle**](https://make.wordpress.org/core/5-9/)
+-->
 
+[**WordPress 5.9の開発サイクル**](https://make.wordpress.org/core/5-9/)
+
+<!--
 [WordPress 5.9 Revised Release Schedule](https://make.wordpress.org/core/2021/11/22/wordpress-5-9-revised-release-schedule/)
+-->
 
+[WordPress 5.9の改訂版リリーススケジュール](https://make.wordpress.org/core/2021/11/22/wordpress-5-9-revised-release-schedule/)
+
+<!--
 📗 Devnotes WordPress 5.9
+-->
 
+📗 WordPress 5.9の開発者ノート
+
+<!--
 [Gutenberg Index 2020](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020/)
+-->
 
+[Gutenberg インデックス 2020](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020/)
+
+<!--
 [Versions on WordPress](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/)
+-->
+
+[WordPress におけるバージョン](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/)
 
 * * *
 
@@ -99,6 +135,7 @@ See *[Explanations](#explanations)* on the bottom.
 2021-11-17 **[#core](https://make.wordpress.org/core/tag/core/)** [WordPress 5.9 Beta 1 delayed](https://make.wordpress.org/core/2021/11/17/wordpress-5-9-beta-1-delayed/) (u)
 
 2021-11-16 **[#design](https://make.wordpress.org/core/tag/design/)** [Show and Tell for Nov. 2021](https://make.wordpress.org/design/2021/11/16/show-and-tell-for-nov-2021/) (u) (*link to the recording is in the comments*)
+
 
 * * *
 
@@ -318,7 +355,11 @@ See *[Explanations](#explanations)* on the bottom.
 
 2021-08-05 **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** [What’s new in Gutenberg 11.2.0? (4 August)](https://make.wordpress.org/core/2021/08/05/whats-new-in-gutenberg-11-2-0-4-august/) (u)
 
+<!--
 ## July 2021
+-->
+
+## 2021年7月
 
 **✴️ = DevNotes for WP 5.8**
 
@@ -882,8 +923,13 @@ See *[Explanations](#explanations)* on the bottom.
 
 * * *
 
-## Explanations
+<!--
+**Explanations**
+-->
 
+**説明**
+
+<!--
 *   **[#team](https://make.wordpress.org/core/tag/team/)** identifies a team’s WordPress Slack channel. [Join the Slack space](https://chat.wordpress.org/).
 *   (m) = Meeting Summaries/Notes, [check here for meeting days and times](http://make.wordpresss.org/meetings)
 *   (r) = general resource
@@ -891,9 +937,30 @@ See *[Explanations](#explanations)* on the bottom.
 *   We use universal date format in yyyy-mm-dd to indicate publication date.
 *   Separators divide the list by weeks
 *   *This page started in January 2021. The index started in July 2020*
+-->
 
+*   **[#team](https://make.wordpress.org/core/tag/team/)** は、チームの WordPress Slack チャンネルを特定します。[Slack スペースに参加する](https://chat.wordpress.org/)。
+*   (m) = ミーティングサマリーやノート。[ミーティング日時はこちらでご確認ください](http://make.wordpresss.org/meetings)。
+*   (r) = 一般的なリソース
+*   (u) = ソフトウェア、方法、プロセス、または議論の更新を示します
+*   投稿日を示すために、yyyy-mm-dd の世界共通の日付形式を使用しています。
+*   セパレーターでリストを週ごとに分割しています。
+*   このページは2021年1月にスタートしました。インデックスは2020年7月より開始しました。
+
+<!--
 Big thanks to Anne McCarthy @annezazu and William Patton @williampatton for support and review.
+-->
 
+Anne McCarthy @annezazu と William Patton @williampatton のサポートとレビューに感謝します。
+
+<!--
 If you find a post missing or you would like to help with this effort, ping Birgit Pauli-Haack (@bph) on Slack with the link and she will add it as soon as possible.
+-->
 
+もし、投稿がないのを見つけたり、この取り組みに協力したい場合は、Slack の Birgit Pauli-Haack (@bph) に連絡していただければ、できるだけ早く追加します。
+
+<!--
 Featured Image: Photo by [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
+-->
+
+アイキャッチ画像: [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) の [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) による写真

--- a/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022.md
+++ b/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022.md
@@ -1,24 +1,64 @@
+<!--
 # Gutenberg Index 2022
+-->
 
+# Gutenberg インデックス 2022
+
+<!--
 This page is the one place you can bookmark for Gutenberg\-related team posts of Core, Core-Editor, Core-js, Core-css, Design, Meta, and Themes, and other teams, when relevant. It’s a chronological listing, not topical. Latest on top.
+-->
 
+このページは、Core、Core-Editor、Core-js、Core-css、Design、Meta、Themes の Gutenberg 関連チームの投稿を、ブックマーク出来るようにするためのものです。時系列順で掲載されており、トピックスではありません。最新のものから並んでいます。
+
+<!--
 Discussions are in the **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack channel and development happens in the [Gutenberg GitHub repository](https://github.com/WordPress/gutenberg/issues).
+-->
 
+議論は **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack チャンネルで、開発は [Gutenberg GitHub リポジトリ](https://github.com/WordPress/gutenberg/issues) で行われています。
+
+<!--
 See *[Explanations](#explanations)* on the bottom.
+-->
+
+下部の「[説明](#explanations)」をご覧ください。
 
 * * *
 
+<!--
 **[WordPress 6.2 Development Cycle](https://make.wordpress.org/core/6-2/)**
+-->
 
+**[WordPress 6.2の開発サイクル](https://make.wordpress.org/core/6-2/)**
+
+<!--
 Previous years of **Gutenberg Index**: **[2020](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020/) | [2021](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021/)**
+-->
 
+過去の **Gutenberg インデックス**: **[2020](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020/) | [2021](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021/)**
+
+<!--
 Gutenberg [Versions in WordPress](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/)
+-->
 
+[WordPress における Gutenberg のバージョン](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/)
+
+<!--
 📗 [Devnotes WordPress 5.9](#devnotes-wordpress-5-9)
+-->
 
+📗 [WordPress 5.9の開発者ノート](#devnotes-wordpress-5-9)
+
+<!--
 📙 [Devnotes WordPress 6.0](https://make.wordpress.org/core/tag/dev-notes-6-0/)
+-->
 
+📙 [WordPress 6.0の開発者ノート](https://make.wordpress.org/core/tag/dev-notes-6-0/)
+
+<!--
 📘 [Devnotes WordPress 6.1](https://make.wordpress.org/core/tag/dev-notes+6.1/)
+-->
+
+📘 [WordPress 6.1の開発者ノート](https://make.wordpress.org/core/tag/dev-notes+6.1/)
 
 * * *
 
@@ -710,9 +750,17 @@ April
 
 2022-01-02 **[#core](https://make.wordpress.org/core/tag/core/)** The December 2021 Team posts moved [to the Index 2021 child page](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021/). This page was prepped for this year. (u)
 
+<!--
 **Happy New Year!** 🎆 🙌 🎉🥂 *Welcome to the 3rd year of Gutenberg Index.*
+-->
 
+**ハッピーニューイヤー !** 🎆 🙌🎉🥂 Gutenberg インデックスの3年目へようこそ。
+
+<!--
 **DevNotes WordPress 5.9**
+-->
+
+**WordPress 6.0の開発者ノート**
 
 *   [Cover Block Refactor Dev Note](https://make.wordpress.org/core/2022/02/09/cover-block-refactor-dev-note/)
 *   [Theme-focused changes and filters in WordPress 5.9](https://make.wordpress.org/core/2022/01/07/theme-focused-changes-and-filters-in-wordpress-5-9/)
@@ -729,8 +777,13 @@ April
 
 * * *
 
+<!--
 **Explanations**
+-->
 
+**説明**
+
+<!--
 *   **[#team](https://make.wordpress.org/core/tag/team/)** identifies a team’s WordPress Slack channel. [Join the Slack space](https://chat.wordpress.org/).
 *   (m) = Meeting Summaries/Notes, [check here for meeting days and times](http://make.wordpresss.org/meetings)
 *   (r) = general resource
@@ -738,11 +791,32 @@ April
 *   We use universal date format in yyyy-mm-dd to indicate publication date.
 *   Separators divide the list by weeks
 *   *This page started in January 2021. The index started in July 2020*
+-->
 
+*   **[#team](https://make.wordpress.org/core/tag/team/)** は、チームの WordPress Slack チャンネルを特定します。[Slack スペースに参加する](https://chat.wordpress.org/)。
+*   (m) = ミーティングサマリーやノート。[ミーティング日時はこちらでご確認ください](http://make.wordpresss.org/meetings)。
+*   (r) = 一般的なリソース
+*   (u) = ソフトウェア、方法、プロセス、または議論の更新を示します
+*   投稿日を示すために、yyyy-mm-dd の世界共通の日付形式を使用しています。
+*   セパレーターでリストを週ごとに分割しています。
+*   このページは2021年1月にスタートしました。インデックスは2020年7月より開始しました。
+
+<!--
 Big thanks to Anne McCarthy @annezazu and William Patton @williampatton for support and review.
+-->
 
+Anne McCarthy @annezazu と William Patton @williampatton のサポートとレビューに感謝します。
+
+<!--
 If you find a post missing or you would like to help with this effort, ping Birgit Pauli-Haack (@bph) on Slack with the link and she will add it as soon as possible.
+-->
 
+もし、投稿がないのを見つけたり、この取り組みに協力したい場合は、Slack の Birgit Pauli-Haack (@bph) に連絡していただければ、できるだけ早く追加します。
+
+<!--
 Featured Image: Photo by [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
+-->
+
+アイキャッチ画像: [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) の [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) による写真
 
 [#announcements](https://make.wordpress.org/core/tag/announcements/), [#core-edtior](https://make.wordpress.org/core/tag/core-edtior/), [#core-media](https://make.wordpress.org/core/tag/core-media/), [#core-privacy](https://make.wordpress.org/core/tag/core-privacy/), [#core-restapi](https://make.wordpress.org/core/tag/core-restapi/), [#core-themes](https://make.wordpress.org/core/tag/core-themes/), [#designer](https://make.wordpress.org/core/tag/designer/), [#forums](https://make.wordpress.org/core/tag/forums/), [#fse-outreach-experiement](https://make.wordpress.org/core/tag/fse-outreach-experiement/), [#mobile](https://make.wordpress.org/core/tag/mobile/), [#news](https://make.wordpress.org/core/tag/news/), [#plugins](https://make.wordpress.org/core/tag/plugins/), [#themes](https://make.wordpress.org/core/tag/themes/), [#themesreview](https://make.wordpress.org/core/tag/themesreview/), [#updates](https://make.wordpress.org/core/tag/updates/)


### PR DESCRIPTION
Closes #110

Gutenberg関連の投稿をリストアップしたページ、計4ページを翻訳しました。（2023/2022/2021/2020）

日本語 GitHubページ (作業したもの): 

- https://github.com/jawordpressorg/core-handbook/blob/translate/keeping-up-with-gutenberg-index/core/references/keeping-up-with-gutenberg-index.md
- https://github.com/jawordpressorg/core-handbook/blob/translate/keeping-up-with-gutenberg-index/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020.md

- https://github.com/jawordpressorg/core-handbook/blob/translate/keeping-up-with-gutenberg-index/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021.md
- https://github.com/jawordpressorg/core-handbook/blob/translate/keeping-up-with-gutenberg-index/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022.md

英語 GitHub ページ:

- https://github.com/jawordpressorg/core-handbook/blob/en/core/references/keeping-up-with-gutenberg-index.md
- https://github.com/jawordpressorg/core-handbook/blob/en/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020.md

- https://github.com/jawordpressorg/core-handbook/blob/en/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021.md
- https://github.com/jawordpressorg/core-handbook/blob/en/core/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022.md

英語 Web ページ: 

- https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/
- https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg- index-2020/
- https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021/
- https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022/

全ページ、冒頭と文末のテキストのみ翻訳しております。原文自体のレイアウトに多少ばらつきはありますが、文言はほとんど同じです。また、文中の年月日は翻訳していませんがこれはWordPressに投稿する時に別途翻訳しようかと思います。