### PR TITLE
translate/tutorials/running-new-contributor-meetings.md

### DIFF
--- a/core/tutorials/running-new-contributor-meetings.md
+++ b/core/tutorials/running-new-contributor-meetings.md
@@ -12,90 +12,90 @@ This is a general script for running new contributor meetings, feel free to edit
 
 * * *
 
-/here <new-contributor-meeting> :wave: Hello everyone! Who’s around for the new contributor meeting?
-
-Great! Anyone attending for the first time?
-
-Awesome, welcome everyone!
-
-Let’s do an open floor section for general questions for the first 20-30 minutes, and then switch to questions on specific tickets for the remainder of the meeting. We usually end 10-15 minutes before the top of the hour to leave a little breathing room for the weekly dev chat.
-
-@desrosj, @flixos90, @mauteri, @adamsilverstein, @welcher, @audrasjb, @costdev, and @sergey are facilitators for these meetings. If you have any questions after the meeting, or anything that you are uncomfortable asking here, you are more than welcome to ping us throughout the week.
-
-If you have any feedback or ideas on making these meetings more helpful, please do suggest 🙂
-
-WordPress Core Contributor Handbook has a great FAQ that should help you get started:
-https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
-
-Does anyone have questions about submitting patches, working with Trac, deciding which tickets to work on, or contributing to core in general?
-
-…
-
-Just in case any new contributors are looking for some bugs to fix, this handbook section suggests some ideas:
-https://make.wordpress.org/core/handbook/contribute/fixing-bugs/#finding-bugs-to-fix
-
-Generally, I would recommend looking at the list of “good first bugs” to get started: https://core.trac.wordpress.org/tickets/good-first-bugs
-
-And here is a similar list of “good first issues” for Gutenberg: https://github.com/WordPress/gutenberg/contribute
-
-If you’re on Twitter, you can follow https://twitter.com/GoodFirstBugs as well 🙂
-
-These are well-contained tasks designed to help you get familiar with WordPress core code, processes, and contributing, and not send you down a rabbit hole 🙂
-
-…
-
-If nothing catches your eye on the “good first bugs” list, I would suggest looking at the tickets marked as needs-patch, needs-testing, needs-design, or needs-design-feedback in the current milestone (6.2):
-https://core.trac.wordpress.org/query?status=!closed&keywords=~good-first-bug&keywords=~needs-patch&keywords=~needs-testing&keywords=~needs-design&keywords=~needs-design-feedback&group=milestone&order=priority
-
-And here you can find all tickets currently slated for the next major release:
-https://core.trac.wordpress.org/tickets/major/workflow
-
-Those are the ones that have a higher priority and need some attention.
-
-…
-
-If you’re interested in triaging, take a look at the tickets that are in the Awaiting Review or Future Release milestone, and see what is needed to move them one step closer to resolution:
-https://core.trac.wordpress.org/tickets/future
-
-…
-
-Also wanted to note that writing code is just one of many ways to contribute, it’s perfectly OK to start with testing the current beta version or nightly build, triaging tickets, adding missing docs, fixing a typo, participating in test scrubs or bug scrubs in [#core-test](https://make.wordpress.org/core/tag/core-test/), etc. 🐛
-
-For tickets that already have a patch, testing an existing patch and giving feedback is also a great way to move them forward 🛣️
-
-…
-
-Some tickets can have multiple patches iterating on a solution or exploring different approaches.
-
-You can just pick a ticket you’re interested in and start working 🙂 Before making significant time investments though, it might be a good idea to ask for an advice in the comments, or here in [#core](https://make.wordpress.org/core/tag/core/).
-
-Some ideas to get more eyes on a ticket once you think it’s ready: pinging the component maintainer for a review in the ticket comments, or bringing it up here in [#core](https://make.wordpress.org/core/tag/core/) any time outside of any ongoing meeting (or in the open floor section of the weekly dev meeting).
-
-…
-
-I’ll pause for any questions now. There are no wrong questions here, don’t be shy, the community is here to support you :wordpress: :community: 🤗
-
-…
-
-If there are no other questions for now, we can open the floor for tickets.
-
-Any specific tickets you’d like to discuss? Let’s see if some of them could be an easy fix 🙂
-
-…
-
-All right, unless anyone has a ticket to bring up, let’s take a look at “good first bugs” that haven’t been modified in a while:
-https://core.trac.wordpress.org/query?status=!closed&keywords=~good-first-bug&order=changetime
-
-…
-
-Any other tickets anyone has questions on or would like to discuss?
-
-…
-
-Alright, we’re at 10 minutes to mark. Going to close out the meeting to allow everyone to take a short break. :coffee: :tea: :cookie: The weekly Core Dev Chat will start at the top of the hour. Everyone is welcome to stick around for it. Again, please feel free to reach out to any of us that run these meetings. ❤️ :community:
-
-Per https://make.wordpress.org/meetings/, the next meeting is in two weeks, August 12, same time as today (19:00 UTC). If you have any questions on contributing to core before that, bring them up here in [#core](https://make.wordpress.org/core/tag/core/) any time outside of any ongoing meeting, or in the open floor section of the weekly dev chat, and someone should follow up.
-
-</new-contributor-meeting>
-
+/here <new-contributor-meeting> :wave: Hello everyone! Who’s around for the new contributor meeting?  
+  
+Great! Anyone attending for the first time?  
+  
+Awesome, welcome everyone!  
+  
+Let’s do an open floor section for general questions for the first 20-30 minutes, and then switch to questions on specific tickets for the remainder of the meeting. We usually end 10-15 minutes before the top of the hour to leave a little breathing room for the weekly dev chat.  
+  
+@desrosj, @flixos90, @mauteri, @adamsilverstein, @welcher, @audrasjb, @costdev, and @sergey are facilitators for these meetings. If you have any questions after the meeting, or anything that you are uncomfortable asking here, you are more than welcome to ping us throughout the week.  
+  
+If you have any feedback or ideas on making these meetings more helpful, please do suggest 🙂  
+  
+WordPress Core Contributor Handbook has a great FAQ that should help you get started:  
+https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/  
+  
+Does anyone have questions about submitting patches, working with Trac, deciding which tickets to work on, or contributing to core in general?  
+  
+…  
+  
+Just in case any new contributors are looking for some bugs to fix, this handbook section suggests some ideas:  
+https://make.wordpress.org/core/handbook/contribute/fixing-bugs/#finding-bugs-to-fix  
+  
+Generally, I would recommend looking at the list of “good first bugs” to get started: https://core.trac.wordpress.org/tickets/good-first-bugs  
+  
+And here is a similar list of “good first issues” for Gutenberg: https://github.com/WordPress/gutenberg/contribute  
+  
+If you’re on Twitter, you can follow https://twitter.com/GoodFirstBugs as well 🙂  
+  
+These are well-contained tasks designed to help you get familiar with WordPress core code, processes, and contributing, and not send you down a rabbit hole 🙂  
+  
+…  
+  
+If nothing catches your eye on the “good first bugs” list, I would suggest looking at the tickets marked as needs-patch, needs-testing, needs-design, or needs-design-feedback in the current milestone (6.2):  
+https://core.trac.wordpress.org/query?status=!closed&keywords=~good-first-bug&keywords=~needs-patch&keywords=~needs-testing&keywords=~needs-design&keywords=~needs-design-feedback&group=milestone&order=priority  
+  
+And here you can find all tickets currently slated for the next major release:  
+https://core.trac.wordpress.org/tickets/major/workflow  
+  
+Those are the ones that have a higher priority and need some attention.  
+  
+…  
+  
+If you’re interested in triaging, take a look at the tickets that are in the Awaiting Review or Future Release milestone, and see what is needed to move them one step closer to resolution:  
+https://core.trac.wordpress.org/tickets/future  
+  
+…  
+  
+Also wanted to note that writing code is just one of many ways to contribute, it’s perfectly OK to start with testing the current beta version or nightly build, triaging tickets, adding missing docs, fixing a typo, participating in test scrubs or bug scrubs in [#core-test](https://make.wordpress.org/core/tag/core-test/), etc. 🐛  
+  
+For tickets that already have a patch, testing an existing patch and giving feedback is also a great way to move them forward 🛣️  
+  
+…  
+  
+Some tickets can have multiple patches iterating on a solution or exploring different approaches.  
+  
+You can just pick a ticket you’re interested in and start working 🙂 Before making significant time investments though, it might be a good idea to ask for an advice in the comments, or here in [#core](https://make.wordpress.org/core/tag/core/).  
+  
+Some ideas to get more eyes on a ticket once you think it’s ready: pinging the component maintainer for a review in the ticket comments, or bringing it up here in [#core](https://make.wordpress.org/core/tag/core/) any time outside of any ongoing meeting (or in the open floor section of the weekly dev meeting).  
+  
+…  
+  
+I’ll pause for any questions now. There are no wrong questions here, don’t be shy, the community is here to support you :wordpress: :community: 🤗  
+  
+…  
+  
+If there are no other questions for now, we can open the floor for tickets.  
+  
+Any specific tickets you’d like to discuss? Let’s see if some of them could be an easy fix 🙂  
+  
+…  
+  
+All right, unless anyone has a ticket to bring up, let’s take a look at “good first bugs” that haven’t been modified in a while:  
+https://core.trac.wordpress.org/query?status=!closed&keywords=~good-first-bug&order=changetime  
+  
+…  
+  
+Any other tickets anyone has questions on or would like to discuss?  
+  
+…  
+  
+Alright, we’re at 10 minutes to mark. Going to close out the meeting to allow everyone to take a short break. :coffee: :tea: :cookie: The weekly Core Dev Chat will start at the top of the hour. Everyone is welcome to stick around for it. Again, please feel free to reach out to any of us that run these meetings. ❤️ :community:  
+  
+Per https://make.wordpress.org/meetings/, the next meeting is in two weeks, August 12, same time as today (19:00 UTC). If you have any questions on contributing to core before that, bring them up here in [#core](https://make.wordpress.org/core/tag/core/) any time outside of any ongoing meeting, or in the open floor section of the weekly dev chat, and someone should follow up.  
+  
+</new-contributor-meeting>  
+  
 Thanks everyone! Happy contributing! 🙌 💪 :wordpress: :community:

--- a/core/tutorials/running-new-contributor-meetings.md
+++ b/core/tutorials/running-new-contributor-meetings.md
@@ -1,93 +1,101 @@
+<!--
 # Running New Contributor Meetings
+-->
 
+# 新しいコントリビューターミーティングの実施
+
+<!--
 This is a general script for running new contributor meetings, feel free to edit as you see fit.
+-->
+
+これは、新しいコントリビューターミーティングを実施するための一般的なスクリプトであり、自由に編集できます。
 
 * * *
 
-/here <new-contributor-meeting> :wave: Hello everyone! Who’s around for the new contributor meeting?  
-  
-Great! Anyone attending for the first time?  
-  
-Awesome, welcome everyone!  
-  
-Let’s do an open floor section for general questions for the first 20-30 minutes, and then switch to questions on specific tickets for the remainder of the meeting. We usually end 10-15 minutes before the top of the hour to leave a little breathing room for the weekly dev chat.  
-  
-@desrosj, @flixos90, @mauteri, @adamsilverstein, @welcher, @audrasjb, @costdev, and @sergey are facilitators for these meetings. If you have any questions after the meeting, or anything that you are uncomfortable asking here, you are more than welcome to ping us throughout the week.  
-  
-If you have any feedback or ideas on making these meetings more helpful, please do suggest 🙂  
-  
-WordPress Core Contributor Handbook has a great FAQ that should help you get started:  
-https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/  
-  
-Does anyone have questions about submitting patches, working with Trac, deciding which tickets to work on, or contributing to core in general?  
-  
-…  
-  
-Just in case any new contributors are looking for some bugs to fix, this handbook section suggests some ideas:  
-https://make.wordpress.org/core/handbook/contribute/fixing-bugs/#finding-bugs-to-fix  
-  
-Generally, I would recommend looking at the list of “good first bugs” to get started: https://core.trac.wordpress.org/tickets/good-first-bugs  
-  
-And here is a similar list of “good first issues” for Gutenberg: https://github.com/WordPress/gutenberg/contribute  
-  
-If you’re on Twitter, you can follow https://twitter.com/GoodFirstBugs as well 🙂  
-  
-These are well-contained tasks designed to help you get familiar with WordPress core code, processes, and contributing, and not send you down a rabbit hole 🙂  
-  
-…  
-  
-If nothing catches your eye on the “good first bugs” list, I would suggest looking at the tickets marked as needs-patch, needs-testing, needs-design, or needs-design-feedback in the current milestone (6.2):  
-https://core.trac.wordpress.org/query?status=!closed&keywords=~good-first-bug&keywords=~needs-patch&keywords=~needs-testing&keywords=~needs-design&keywords=~needs-design-feedback&group=milestone&order=priority  
-  
-And here you can find all tickets currently slated for the next major release:  
-https://core.trac.wordpress.org/tickets/major/workflow  
-  
-Those are the ones that have a higher priority and need some attention.  
-  
-…  
-  
-If you’re interested in triaging, take a look at the tickets that are in the Awaiting Review or Future Release milestone, and see what is needed to move them one step closer to resolution:  
-https://core.trac.wordpress.org/tickets/future  
-  
-…  
-  
-Also wanted to note that writing code is just one of many ways to contribute, it’s perfectly OK to start with testing the current beta version or nightly build, triaging tickets, adding missing docs, fixing a typo, participating in test scrubs or bug scrubs in [#core-test](https://make.wordpress.org/core/tag/core-test/), etc. 🐛  
-  
-For tickets that already have a patch, testing an existing patch and giving feedback is also a great way to move them forward 🛣️  
-  
-…  
-  
-Some tickets can have multiple patches iterating on a solution or exploring different approaches.  
-  
-You can just pick a ticket you’re interested in and start working 🙂 Before making significant time investments though, it might be a good idea to ask for an advice in the comments, or here in [#core](https://make.wordpress.org/core/tag/core/).  
-  
-Some ideas to get more eyes on a ticket once you think it’s ready: pinging the component maintainer for a review in the ticket comments, or bringing it up here in [#core](https://make.wordpress.org/core/tag/core/) any time outside of any ongoing meeting (or in the open floor section of the weekly dev meeting).  
-  
-…  
-  
-I’ll pause for any questions now. There are no wrong questions here, don’t be shy, the community is here to support you :wordpress: :community: 🤗  
-  
-…  
-  
-If there are no other questions for now, we can open the floor for tickets.  
-  
-Any specific tickets you’d like to discuss? Let’s see if some of them could be an easy fix 🙂  
-  
-…  
-  
-All right, unless anyone has a ticket to bring up, let’s take a look at “good first bugs” that haven’t been modified in a while:  
-https://core.trac.wordpress.org/query?status=!closed&keywords=~good-first-bug&order=changetime  
-  
-…  
-  
-Any other tickets anyone has questions on or would like to discuss?  
-  
-…  
-  
-Alright, we’re at 10 minutes to mark. Going to close out the meeting to allow everyone to take a short break. :coffee: :tea: :cookie: The weekly Core Dev Chat will start at the top of the hour. Everyone is welcome to stick around for it. Again, please feel free to reach out to any of us that run these meetings. ❤️ :community:  
-  
-Per https://make.wordpress.org/meetings/, the next meeting is in two weeks, August 12, same time as today (19:00 UTC). If you have any questions on contributing to core before that, bring them up here in [#core](https://make.wordpress.org/core/tag/core/) any time outside of any ongoing meeting, or in the open floor section of the weekly dev chat, and someone should follow up.  
-  
-</new-contributor-meeting>  
-  
+/here <new-contributor-meeting> :wave: Hello everyone! Who’s around for the new contributor meeting?
+
+Great! Anyone attending for the first time?
+
+Awesome, welcome everyone!
+
+Let’s do an open floor section for general questions for the first 20-30 minutes, and then switch to questions on specific tickets for the remainder of the meeting. We usually end 10-15 minutes before the top of the hour to leave a little breathing room for the weekly dev chat.
+
+@desrosj, @flixos90, @mauteri, @adamsilverstein, @welcher, @audrasjb, @costdev, and @sergey are facilitators for these meetings. If you have any questions after the meeting, or anything that you are uncomfortable asking here, you are more than welcome to ping us throughout the week.
+
+If you have any feedback or ideas on making these meetings more helpful, please do suggest 🙂
+
+WordPress Core Contributor Handbook has a great FAQ that should help you get started:
+https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
+
+Does anyone have questions about submitting patches, working with Trac, deciding which tickets to work on, or contributing to core in general?
+
+…
+
+Just in case any new contributors are looking for some bugs to fix, this handbook section suggests some ideas:
+https://make.wordpress.org/core/handbook/contribute/fixing-bugs/#finding-bugs-to-fix
+
+Generally, I would recommend looking at the list of “good first bugs” to get started: https://core.trac.wordpress.org/tickets/good-first-bugs
+
+And here is a similar list of “good first issues” for Gutenberg: https://github.com/WordPress/gutenberg/contribute
+
+If you’re on Twitter, you can follow https://twitter.com/GoodFirstBugs as well 🙂
+
+These are well-contained tasks designed to help you get familiar with WordPress core code, processes, and contributing, and not send you down a rabbit hole 🙂
+
+…
+
+If nothing catches your eye on the “good first bugs” list, I would suggest looking at the tickets marked as needs-patch, needs-testing, needs-design, or needs-design-feedback in the current milestone (6.2):
+https://core.trac.wordpress.org/query?status=!closed&keywords=~good-first-bug&keywords=~needs-patch&keywords=~needs-testing&keywords=~needs-design&keywords=~needs-design-feedback&group=milestone&order=priority
+
+And here you can find all tickets currently slated for the next major release:
+https://core.trac.wordpress.org/tickets/major/workflow
+
+Those are the ones that have a higher priority and need some attention.
+
+…
+
+If you’re interested in triaging, take a look at the tickets that are in the Awaiting Review or Future Release milestone, and see what is needed to move them one step closer to resolution:
+https://core.trac.wordpress.org/tickets/future
+
+…
+
+Also wanted to note that writing code is just one of many ways to contribute, it’s perfectly OK to start with testing the current beta version or nightly build, triaging tickets, adding missing docs, fixing a typo, participating in test scrubs or bug scrubs in [#core-test](https://make.wordpress.org/core/tag/core-test/), etc. 🐛
+
+For tickets that already have a patch, testing an existing patch and giving feedback is also a great way to move them forward 🛣️
+
+…
+
+Some tickets can have multiple patches iterating on a solution or exploring different approaches.
+
+You can just pick a ticket you’re interested in and start working 🙂 Before making significant time investments though, it might be a good idea to ask for an advice in the comments, or here in [#core](https://make.wordpress.org/core/tag/core/).
+
+Some ideas to get more eyes on a ticket once you think it’s ready: pinging the component maintainer for a review in the ticket comments, or bringing it up here in [#core](https://make.wordpress.org/core/tag/core/) any time outside of any ongoing meeting (or in the open floor section of the weekly dev meeting).
+
+…
+
+I’ll pause for any questions now. There are no wrong questions here, don’t be shy, the community is here to support you :wordpress: :community: 🤗
+
+…
+
+If there are no other questions for now, we can open the floor for tickets.
+
+Any specific tickets you’d like to discuss? Let’s see if some of them could be an easy fix 🙂
+
+…
+
+All right, unless anyone has a ticket to bring up, let’s take a look at “good first bugs” that haven’t been modified in a while:
+https://core.trac.wordpress.org/query?status=!closed&keywords=~good-first-bug&order=changetime
+
+…
+
+Any other tickets anyone has questions on or would like to discuss?
+
+…
+
+Alright, we’re at 10 minutes to mark. Going to close out the meeting to allow everyone to take a short break. :coffee: :tea: :cookie: The weekly Core Dev Chat will start at the top of the hour. Everyone is welcome to stick around for it. Again, please feel free to reach out to any of us that run these meetings. ❤️ :community:
+
+Per https://make.wordpress.org/meetings/, the next meeting is in two weeks, August 12, same time as today (19:00 UTC). If you have any questions on contributing to core before that, bring them up here in [#core](https://make.wordpress.org/core/tag/core/) any time outside of any ongoing meeting, or in the open floor section of the weekly dev chat, and someone should follow up.
+
+</new-contributor-meeting>
+
 Thanks everyone! Happy contributing! 🙌 💪 :wordpress: :community:


### PR DESCRIPTION
Closes #124

日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/0f1d071b699292930a785cf0884d882831cfabab/core/tutorials/running-new-contributor-meetings.md
英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/aa1c64eeda29b12ed46ee0ee01b3be756ee19c46/core/tutorials/running-new-contributor-meetings.md
英語 Web ページ: https://make.wordpress.org/core/handbook/tutorials/running-new-contributor-meetings/

### Note

このページは、Making WordPressのSlackチャンネルでミーティングを開催する時のスクリプト（雛形）について説明しています。通常、Make WordPressでは英語でチャットが行われるので、スクリプト本文は未翻訳とし、導入文のみ翻訳しました。