### PR TITLE
translate/tutorials/core-team-rep-election-process.md

### DIFF
--- a/core/tutorials/core-team-rep-election-process.md
+++ b/core/tutorials/core-team-rep-election-process.md
@@ -1,54 +1,161 @@
+<!--
 # Core Team Rep Election Process
+-->
 
+# コアチーム代表選出の流れ
+
+<!--
 In summary, the process follows three subsequent Make/Core posts for [nominations](https://make.wordpress.org/core/2020/04/29/nominations-for-core-team-reps/), [voting](https://make.wordpress.org/core/2020/05/15/core-team-reps-submit-your-votes/), and then [announcing](https://make.wordpress.org/core/2020/06/03/core-team-reps-for-2020-and-beyond/) new Core Team Reps.
+-->
 
+要約すると、[推薦](https://make.wordpress.org/core/2020/04/29/nominations-for-core-team-reps/)、[投票](https://make.wordpress.org/core/2020/05/15/core-team-reps-submit-your-votes/)、そして[発表](https://make.wordpress.org/core/2020/06/03/core-team-reps-for-2020-and-beyond/)という3つの Make/Core 投稿を経て、新しいコアチーム代表が選出されます。
+
+<!--
 ## The Role
+-->
 
+## 役割
+
+<!--
 In the WordPress open source project, each team has on average one or two representatives, abbreviated as *reps*.  Some teams have more than two, but for the sake of sanity sticking with two for now keeps things simpler.  And for the historians out there, the role goes [way back to 2012](https://make.wordpress.org/updates/team-reps/).
+-->
 
+WordPress のオープンソースプロジェクトでは、各チームに平均1～2名の代表者がおり、*reps* と略されます。 チームによっては2人以上いることもありますが、物事をシンプルに進めるために、今のところ2人にしておくと良いでしょう。 そして歴史が好きな人のために、この役割は[2012年までさかのぼります](https://make.wordpress.org/updates/team-reps/)。
+
+<!--
 Historically with the Core team, the team rep duration was around a year, though some reps stuck around longer if there was a particularly good fit.
+-->
 
+コアチームではこれまで、チーム代表者の期間は1年程度でしたが、特に相性の合う代表者はもっと長く在籍していました。
+
+<!--
 Anyone who serves as a “**team rep**” is responsible for communicating on behalf of the Core team to the other contributor groups via [weekly updates](https://make.wordpress.org/updates/), as well as occasional cross-team chats.  Reps are also consulted on Contributor Day, helping find someone within the Core team attending an event who can help lead a Core table.  [Full details on the Team Rep role is on the Team Update site.](https://make.wordpress.org/updates/team-reps/)
+-->
 
+「**チーム代表者**」として働く人はコアチームの代表として、[ウィークリーアップデート](https://make.wordpress.org/updates/)を通じて他のコントリビューターグループと、また時々チーム間のチャットを介してコミュニケーションを取る責任があります。また、コントリビューターデイでは、イベントに参加するコアチームの中から、コアテーブルをリードできる人を見つける手助けをするために相談されます。 [チーム代表者の役割の詳細は、チームアップデートサイトにあります](https://make.wordpress.org/updates/team-reps/)。
+
+<!--
 **It is not called “team lead” for a reason.**  While people elected as team reps will generally come from the pool of folks that people think of as experienced leaders, remember that the team rep role is designed to change hands regularly.
+-->
 
+**「チームリーダー」と呼ばないことには理由があります。** チーム代表として選出される人は、一般的に経験豊富なリーダーと思われる人たちから選ばれますが、チーム代表の役割は定期的に交代するように設計されていることを忘れないでください。
+
+<!--
 This role has a time commitment attached to it.  Not a huge amount, but in my experience, it’s at least one hour a week.
+-->
 
+この役割には時間的な制約がつきものです。 膨大な量ではありませんが、私の経験では、少なくとも週に1時間です。
+
+<!--
 Here are the main tasks:
+-->
 
+主なタスクを紹介します:
+
+<!--
 *   Post the devchat agenda, host the chats, and summarizing them. [More details on coordinating devchat are available in the Core handbook.](https://make.wordpress.org/core/handbook/tutorials/coordinating-devchat/)
 *   Writing regular Core team recaps and posting it in [Updates](https://make.wordpress.org/updates)
 *   Write the [Week in Review](https://make.wordpress.org/core/tag/week-in-core/) post
 *   Keeping an eye on the moving parts of the team to be able to report for quarterly updates ([example](https://make.wordpress.org/updates/2018/04/24/quarterly-updates-q1-2018/))
+-->
 
+* 開発チャットのアジェンダを投稿し、チャットを主催し、それを要約します。[開発チャットの調整に関する詳細はコアハンドブックに掲載されています。](https://make.wordpress.org/core/handbook/tutorials/coordinating-devchat/)
+* 定期的なコアチームの要約を書き、[Updates](https://make.wordpress.org/updates) に投稿する。
+* [Week in Review](https://make.wordpress.org/core/tag/week-in-core/) の投稿を書く。
+* 四半期ごとの更新で報告するために、チームの動きに目を配る ([例](https://make.wordpress.org/updates/2018/04/24/quarterly-updates-q1-2018/))
+
+<!--
 [More details on coordinating devchat are available in the Core handbook.](https://make.wordpress.org/core/handbook/tutorials/coordinating-devchat/)
+-->
 
+[開発チャットの調整に関する詳細は、コアハンドブックに掲載されています。](https://make.wordpress.org/core/handbook/tutorials/coordinating-devchat/)
+
+<!--
 ## Nominating
+-->
 
+## 推薦
+
+<!--
 **Nominations** happen in the comments of a Core Team Reps nomination post (here are examples from [2020](https://make.wordpress.org/core/2020/04/29/nominations-for-core-team-reps/) and [2021](https://make.wordpress.org/core/2021/10/26/nominations-for-core-team-reps-2022/) as well as a [sample Community Team nominating post](https://make.wordpress.org/community/2019/12/05/community-team-reps-for-2020/)).  Self-nominations are welcome.  The deadline for nominations should be around two weeks.  
+-->
 
+**推薦** は、コアチーム代表者の推薦投稿のコメントで行われます (ここでは[2020](https://make.wordpress.org/core/2020/04/29/nominations-for-core-team-reps/)と[2021](https://make.wordpress.org/core/2021/10/26/nominations-for-core-team-reps-2022/)の例、および[コミュニティチームの推薦投稿例](https://make.wordpress.org/community/2019/12/05/community-team-reps-for-2020/)を紹介します)。自薦も歓迎されます。推薦の締め切りは、2週間程度とします。
+
+<!--
 Preference is for nominations to happen publicly, but if someone wants to nominate someone in private, they can reach out to existing team reps and any other active contributors assisting the process via Slack.
+-->
 
+推薦は公の場で行われることが望ましいですが、もし誰かが個人的に指名したい場合は、Slack を通じて既存のチーム代表者やプロセスを支援する他の積極的な貢献者に連絡できます。
+
+<!--
 *An important disclaimer: if someone is nominated, they should not feel like they have to say “yes”.  The polls will only include the names of the people that respond positively to a nomination.  Anyone who is nominated should feel free to reply with a “Thank you, but no thank you”.*
+-->
 
+**重要な免責事項**: 誰かに推薦された場合、「はい」と言わなければならないように感じるべきではありません。 投票では、推薦に対して肯定的な回答をした人の名前だけが掲載されます。推薦された人は、「ありがとうございます、でも結構です」と遠慮なく答えることもできます。
+
+<!--
 Once the deadline has passed for nominating, a comment will be added and pinned to the top of the nomination post:
+-->
 
+推薦期限が過ぎると、コメントが追加され、推薦記事のトップにピン留めされます:
+
+<!--
 *Nominations are now closed and voting is open until <voting deadline>. Voting details and link here:* [](https://make.wordpress.org/core/)*[https://make.wordpress.org/core/](https://make.wordpress.org/core/)**<voting-link>/*
+-->
 
+「推薦を締め切りましたので、<投票締め切り> まで投票を受け付けます。投票の詳細とリンクはこちら: [https://make.wordpress.org/core/](https://make.wordpress.org/core/)<voting-link>/」
+
+<!--
 ## Voting
+-->
 
+## 投票
+
+<!--
 After nominations have ended, a poll for **voting** will be opened and linked from a voting announcement post (here is an example from [2020](https://make.wordpress.org/core/2020/05/15/core-team-reps-submit-your-votes/) as well as a [sample Community Team voting post](https://make.wordpress.org/community/2020/01/15/community-team-reps-submit-your-votes/)).  It should stay open for around two weeks.
+-->
 
+推薦が終了した後、**投票**用のページが開設され、投票を告知した記事からリンクされます (ここでは、[2020](https://make.wordpress.org/core/2020/05/15/core-team-reps-submit-your-votes/)の例と、[コミュニティチームの投票投稿例](https://make.wordpress.org/community/2020/01/15/community-team-reps-submit-your-votes/)の例を示します)。2週間程度は受け付けているはずです。
+
+<!--
 Once the deadline has passed for voting, a comment will be added and pinned to the top of the voting post:
+-->
 
+投票期限が過ぎると、コメントが追加され、投票記事のトップにピン留めされます:
+
+<!--
 *Voting has concluded and the new team reps will be announced on <date> during the Core devchat.*
+-->
 
+「投票は終了し、新しいチーム代表者は <日付> にコア開発者チャットで発表される予定です。」
+
+<!--
 Once the results have been finalized and announced, a comment will be added and pinned to the top of the voting post:
+-->
 
+結果が確定し発表された時点で、投票記事のトップにコメントが追加され、ピン留めされます:
+
+<!--
 *Selected Core Team reps are announced here: <a href="https://make.wordpress.org/core//”>https://make.wordpress.org/core/<results-link>/*
+-->
 
+「選出されたコアチームの代表者はこちらで発表しています: <a href="https://make.wordpress.org/core//">https://make.wordpress.org/core/<results-link>/」
+
+<!--
 ## Announcing
+-->
 
+## 発表
+
+<!--
 After voting has ended, **results** should be shared in an announcement post (here is an exmaple from [2020](https://make.wordpress.org/core/2020/06/03/core-team-reps-for-2020-and-beyond/) as well as a [sample Community Team results post)](https://make.wordpress.org/community/2020/02/06/community-team-reps-for-2020-2/).  Similarly, the new team rep(s) should be updated on the [Team Reps page](https://make.wordpress.org/updates/team-reps/).
+-->
 
+投票終了後、**結果**はアナウンス記事で共有する必要があります ([2020](https://make.wordpress.org/core/2020/06/03/core-team-reps-for-2020-and-beyond/)の例と、[コミュニティチームの投票結果の投稿例](https://make.wordpress.org/community/2020/02/06/community-team-reps-for-2020-2/)があります)。 同様に、新しいチーム代表者は、[チーム代表者ページ](https://make.wordpress.org/updates/team-reps/)で更新される必要があります。
+
+<!--
 The outgoing team rep(s) should plan to be available for questions and consultation from the incoming team rep(s) as there will undoubtedly be a learning curve as new rep(s) get into the role.
+-->
+
+退任するチーム代表者は、新しいチーム代表者がその役割に慣れるまで時間がかかるため、次のチーム代表者からの質問や相談に対応できるよう計画する必要があります。

--- a/core/tutorials/core-team-rep-election-process.md
+++ b/core/tutorials/core-team-rep-election-process.md
@@ -104,7 +104,7 @@ Once the deadline has passed for nominating, a comment will be added and pinned 
 *Nominations are now closed and voting is open until <voting deadline>. Voting details and link here:* [](https://make.wordpress.org/core/)*[https://make.wordpress.org/core/](https://make.wordpress.org/core/)**<voting-link>/*
 -->
 
-「推薦を締め切りましたので、<投票締め切り> まで投票を受け付けます。投票の詳細とリンクはこちら: https://make.wordpress.org/core/`<voting-link>`/」
+「推薦を締め切りましたので、<投票締め切り> まで投票を受け付けます。投票の詳細とリンクはこちら: [https://make.wordpress.org/core/](https://make.wordpress.org/core/)`<voting-link>`/」
 
 <!--
 ## Voting
@@ -140,7 +140,7 @@ Once the results have been finalized and announced, a comment will be added and 
 *Selected Core Team reps are announced here: <a href="https://make.wordpress.org/core//”>https://make.wordpress.org/core/<results-link>/*
 -->
 
-「選出されたコアチームの代表者はこちらで発表しています: https://make.wordpress.org/core/`<results-link>`/」
+「選出されたコアチームの代表者はこちらで発表しています: [https://make.wordpress.org/core/](https://make.wordpress.org/core/)`<results-link>`/」
 
 <!--
 ## Announcing

--- a/core/tutorials/core-team-rep-election-process.md
+++ b/core/tutorials/core-team-rep-election-process.md
@@ -104,7 +104,7 @@ Once the deadline has passed for nominating, a comment will be added and pinned 
 *Nominations are now closed and voting is open until <voting deadline>. Voting details and link here:* [](https://make.wordpress.org/core/)*[https://make.wordpress.org/core/](https://make.wordpress.org/core/)**<voting-link>/*
 -->
 
-「推薦を締め切りましたので、<投票締め切り> まで投票を受け付けます。投票の詳細とリンクはこちら: [https://make.wordpress.org/core/](https://make.wordpress.org/core/)<voting-link>/」
+「推薦を締め切りましたので、<投票締め切り> まで投票を受け付けます。投票の詳細とリンクはこちら: https://make.wordpress.org/core/<voting-link>/」
 
 <!--
 ## Voting
@@ -140,7 +140,7 @@ Once the results have been finalized and announced, a comment will be added and 
 *Selected Core Team reps are announced here: <a href="https://make.wordpress.org/core//”>https://make.wordpress.org/core/<results-link>/*
 -->
 
-「選出されたコアチームの代表者はこちらで発表しています: <a href="https://make.wordpress.org/core//">https://make.wordpress.org/core/<results-link>/」
+「選出されたコアチームの代表者はこちらで発表しています: https://make.wordpress.org/core/<results-link>/」
 
 <!--
 ## Announcing

--- a/core/tutorials/core-team-rep-election-process.md
+++ b/core/tutorials/core-team-rep-election-process.md
@@ -104,7 +104,7 @@ Once the deadline has passed for nominating, a comment will be added and pinned 
 *Nominations are now closed and voting is open until <voting deadline>. Voting details and link here:* [](https://make.wordpress.org/core/)*[https://make.wordpress.org/core/](https://make.wordpress.org/core/)**<voting-link>/*
 -->
 
-「推薦を締め切りましたので、<投票締め切り> まで投票を受け付けます。投票の詳細とリンクはこちら: https://make.wordpress.org/core/<voting-link>/」
+「推薦を締め切りましたので、<投票締め切り> まで投票を受け付けます。投票の詳細とリンクはこちら: https://make.wordpress.org/core/`<voting-link>`/」
 
 <!--
 ## Voting
@@ -140,7 +140,7 @@ Once the results have been finalized and announced, a comment will be added and 
 *Selected Core Team reps are announced here: <a href="https://make.wordpress.org/core//”>https://make.wordpress.org/core/<results-link>/*
 -->
 
-「選出されたコアチームの代表者はこちらで発表しています: https://make.wordpress.org/core/<results-link>/」
+「選出されたコアチームの代表者はこちらで発表しています: https://make.wordpress.org/core/`<results-link>`/」
 
 <!--
 ## Announcing


### PR DESCRIPTION
Closes #123

日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/6a03770e52399157894d3cdfe3322be18254299b/core/tutorials/core-team-rep-election-process.md
英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/aa1c64eeda29b12ed46ee0ee01b3be756ee19c46/core/tutorials/core-team-rep-election-process.md
英語 Web ページ: https://make.wordpress.org/core/handbook/tutorials/core-team-rep-election-process/

### Note

意訳した箇所が数か所あるため、コメントで追記していきます。