### PR TITLE
translate/index.md

### DIFF
--- a/core/index.md
+++ b/core/index.md
@@ -1,39 +1,119 @@
+<!--
 # Core Contributor Handbook
+-->
 
+# コアコントリビューターハンドブック
+
+<!--
 Welcome to the Core Contributor Handbook, the place to learn how to get involved with the WordPress core development community, and start contributing to WordPress core.
+-->
 
+コアコントリビューターハンドブックへようこそ。ここはコア開発コミュニティに参加し、WordPress コアへの貢献を開始する方法を学ぶ場です。
+
+<!--
 Whether you are a beta tester, casual contributor, or serious contributor, this handbook will provide the information you need to get started.
+-->
 
+ベータテスターであっても、カジュアルな貢献者であっても、本格的な貢献者であっても、このハンドブックは必要な情報を提供します。
+
+<!--
 Here you can learn about how the WordPress project is organized, communication channels, best practices, the Trac workflow process, and more. There are also guides to help you set up the tools you’ll need to start contributing to WordPress core.
+-->
 
+ここでは、WordPress プロジェクトがどのように組織されているか、コミュニケーションチャネル、ベストプラクティス、Trac のワークフロープロセスなどについて学ぶことができます。また、WordPress コアへの貢献を開始するために必要なツールのセットアップを支援するガイドもあります。
+
+<!--
 ## Contribute with Testing
+-->
 
+## テストで貢献する
+
+<!--
 Testing is a very important part of the release cycle. You can install the latest development version locally to test new features, and how the changes work with your site setup (theme/plugins/etc.). You can [start testing](https://make.wordpress.org/core/handbook/testing/) as soon as a new development version is available (alpha), and continue throughout the release cycle to ensure the next version of WordPress is as bug\-free as possible.
+-->
 
+テストは、リリースサイクルの非常に重要な部分です。最新の開発版をローカルにインストールし、新機能や、サイトの設定 (テーマやプラグインなど) での変更点の動作をテストできます。新しい開発版 (アルファ版) が利用可能になるとすぐに[テストを開始](https://make.wordpress.org/core/handbook/testing/)でき、次のバージョンの WordPress ができるだけバグがないことを保証するためにリリースサイクル全体を通して継続します。
+
+<!--
 You don’t need to know how to code or create a patch, just provide a [well-written bug report](https://make.wordpress.org/core/handbook/testing/reporting-bugs/), with details of the issue and steps to reproduce. You can confirm the issue is fixed once a patch is committed and a new bleeding edge nightly version released.
+-->
 
+コーディングやパッチの作成方法を知っている必要はありません。問題の詳細と再現手順を記載した[バグレポート](https://make.wordpress.org/core/handbook/testing/reporting-bugs/)を提供してください。パッチがコミットされ、新しい最先端のナイトリーバージョンがリリースされた時点で、問題が修正されたことを確認できます。
+
+<!--
 Found a security vulnerability? WordPress believes in responsible and private disclosure. [Report it directly to our security team.](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/)
+-->
 
+セキュリティの脆弱性を発見されましたか ? WordPress は、責任ある非公開の情報公開を信条としています。[セキュリティチームに直接報告してください。](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/)
+
+<!--
 ## Contribute with Code
+-->
 
+## コードで貢献する
+
+<!--
 Whether you need to report one bug and provide a patch to fix it, or wish to become involved in maintaining one or more WordPress components, contributing code is a great way to improve WordPress. This section walks through [the WordPress codebase](https://make.wordpress.org/core/handbook/contribute/codebase/) and how it’s laid out, then teaches you more about [the code repository](https://make.wordpress.org/core/handbook/contribute/svn/) and [our bug tracker (Trac)](https://make.wordpress.org/core/handbook/contribute/trac/).
+-->
 
+バグを報告して修正パッチを提供する必要がある場合でも、1つ以上の WordPress コンポーネントのメンテナンスに関与したい場合でも、コードの貢献は WordPress を改善するすばらしい方法です。このセクションでは、[WordPress のコードベース](https://make.wordpress.org/core/handbook/contribute/codebase/)とそのレイアウトについて説明し、[コードリポジトリ](https://make.wordpress.org/core/handbook/contribute/svn/)と[バグトラッカーである Trac](https://make.wordpress.org/core/handbook/contribute/trac/) について詳しく説明します。
+
+<!--
 [Design decisions](https://make.wordpress.org/core/handbook/contribute/design-decisions/) made within WordPress are often a consideration when contributing code and are outlined in this section as well. Finally, if you’re interested in [fixing bugs](https://make.wordpress.org/core/handbook/contribute/fixing-bugs/), our walkthrough is made to get you quickly started.
+-->
 
+WordPress の[デザインの決定](https://make.wordpress.org/core/handbook/contribute/design-decisions/)は、コードを提供する際にしばしば考慮されることであり、このセクションでも説明されています。最後に、もし[バグ修正](https://make.wordpress.org/core/handbook/contribute/fixing-bugs/)に興味があるなら、ウォークスルーはすぐに始められるように作られています。
+
+<!--
 ## Best Practices
+-->
 
+## ベストプラクティス
+
+<!--
 Over time, the WordPress community has developed some [best practices](https://make.wordpress.org/core/handbook/best-practices/), which keep the code base consistent and understandable by the community.
+-->
 
+時間をかけて、WordPress コミュニティはいくつかの[ベストプラクティス](https://make.wordpress.org/core/handbook/best-practices/)を開発し、コードベースの一貫性とコミュニティの理解力を維持しています。
+
+<!--
 In the best practices section, we outline the [coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) for [CSS](https://make.wordpress.org/core/handbook/best-practices/coding-standards/css/), [HTML](https://make.wordpress.org/core/handbook/best-practices/coding-standards/html/), [JavaScript](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/), and [PHP](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/). Additionally, [inline documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/) for both [JavaScript](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/) and [PHP](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/) are documented in-depth.
+-->
 
+ベストプラクティスでは、[CSS](https://make.wordpress.org/core/handbook/best-practices/coding-standards/css/)、[HTML](https://make.wordpress.org/core/handbook/best-practices/coding-standards/html/)、[JavaScript](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/)、[PHP](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/) の[コーディング規約](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)について概説しています。さらに、[JavaScript](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/) と [PHP](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/) の両方の[インラインドキュメント標準](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/)について詳しく説明しています。
+
+<!--
 Finally, the section walks through the [Core APIs](https://make.wordpress.org/core/handbook/best-practices/core-apis/) and the best practices to follow when [writing patches](https://make.wordpress.org/core/handbook/best-practices/writing-patches/).
+-->
 
+最後に、[コア API](https://make.wordpress.org/core/handbook/best-practices/core-apis/) と[パッチを書く](https://make.wordpress.org/core/handbook/best-practices/writing-patches/)際に従うべきベストプラクティスを説明します。
+
+<!--
 ## Tutorials & Guides
+-->
 
+## チュートリアル & ガイド
+
+<!--
 Completely new to WordPress development? In this section, we include a number of [tutorials and guides](https://make.wordpress.org/core/handbook/tutorials/) to help get you setup. Whether you want to [setup WordPress for local development](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/), [install a local server](https://make.wordpress.org/core/handbook/tutorials/installing-a-local-server/), [install a version control system (VCS)](https://make.wordpress.org/core/handbook/tutorials/installing-a-vcs/), understand how to [work with patches](https://make.wordpress.org/core/handbook/tutorials/working-with-patches/), or better understand how to [work with Trac](https://make.wordpress.org/core/handbook/tutorials/trac/), we have you covered.
+-->
 
+WordPress の開発は初めてですか ? このセクションでは、セットアップに役立つ[チュートリアルとガイド](https://make.wordpress.org/core/handbook/tutorials/)を多数掲載しています。[WordPress をローカルで開発するためのセットアップ](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/)、[ローカルサーバーのインストール](https://make.wordpress.org/core/handbook/tutorials/installing-a-local-server/)、[バージョン管理システム (VCS) のインストール](https://make.wordpress.org/core/handbook/tutorials/installing-a-vcs/)、[パッチの扱い](https://make.wordpress.org/core/handbook/tutorials/working-with-patches/)、または [Trac](https://make.wordpress.org/core/handbook/tutorials/trac/) について理解したいのかをカバーしています。
+
+<!--
 ## Need help?
+-->
 
+## ヘルプが必要ですか ?
+
+<!--
 We all start somewhere. If you’re having trouble getting involved with contributing to WordPress core, come find us on [Slack](https://chat.wordpress.org/) in [#core](https://make.wordpress.org/core/tag/core/). We don’t bite. 😊
+-->
 
+皆、どこかしらから始めています。もし WordPress のコアへの貢献について悩んでいるなら、[Slack](https://chat.wordpress.org/) の [#core](https://make.wordpress.org/core/tag/core/) へ来てください。噛みついたりしませんよ😊
+
+<!--
 Note: If you’re interested in improving this handbook, leave a message in #core\-docs.
+-->
+
+注意: このハンドブックの改善に興味がある方は、#core\-docs にメッセージを残してください。


### PR DESCRIPTION
Closes: #54

ハンドブックのトップページです。自動クローズされたPR （#66） の翻訳をそのまま移行しています。

- 日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/9b9dda35d81c99664990da0f9ad45b9176095a63/core/index.md
- 英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/index.md
- 英語 Web ページ: https://make.wordpress.org/core/handbook/