### PR TITLE
translate/about/licensing.md

### DIFF
--- a/core/about/licensing.md
+++ b/core/about/licensing.md
@@ -1,15 +1,43 @@
+<!--
 # Licensing &amp; Copyright
+-->
+
+# ライセンスと著作権
 
 ## GNU GPL
 
+<!--
 The license under which the WordPress software is released is the GPLv2 (or later) from the [Free Software Foundation](http://www.fsf.org/). A copy of the license is included with every copy of WordPress, but you can also read [the text of the license](https://wordpress.org/about/gpl/) here.
+-->
 
+WordPress ソフトウェアがリリースされるライセンスは、[フリーソフトウェア財団](http://www.fsf.org/)の GPLv2 (またはそれ以降) です。ライセンスのコピーは WordPress のすべてのコピーに含まれていますが、[ライセンスのテキスト](https://wordpress.org/about/gpl/)をここで読むこともできます。
+
+<!--
 *Still lost? We have a [beginner’s GPL primer](https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/gpl-primer/), too.*
+-->
 
+*まだ迷っていますか ? [初心者のためのGPL入門](https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/gpl-primer/)もあります。*
+
+<!--
 ## Third Party Libraries
+-->
 
+## サードパーティライブラリ
+
+<!--
 Third-Party libraries must be GPLv2 compatible, but retain their own copyright.
+-->
 
+サードパーティライブラリは GPLv2 と互換性がある必要がありますが、独自の著作権を保持します。
+
+<!--
 ## Contributor Copyright
+-->
 
+## 貢献者の著作権
+
+<!--
 As a contributor, you retain the copyright to your code, however by submitting it to Trac you are releasing it under the GPLv2.
+-->
+
+コントリビュータとして、あなたのコードの著作権は保持しますが、 Trac に投稿することで GPLv2 の下でリリースすることになります。


### PR DESCRIPTION
Closes: #137

- 日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/4cc77791f8ae3351dc6034aebea4f47ee18359bb/core/about/licensing.md
- 英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/about/licensing.md
- 英語 Web ページ: https://make.wordpress.org/core/handbook/about/licensing/