### PR TITLE
translate/best-practices/when-you-become-a-committer.md

### DIFF
--- a/core/best-practices/when-you-become-a-committer.md
+++ b/core/best-practices/when-you-become-a-committer.md
@@ -1,7 +1,16 @@
+<!--
 # When you become a committer
+-->
 
+# コミッターになったら
+
+<!--
 Welcome to being a committer! Here are some things you should know:
+-->
 
+コミッターになることを歓迎します ! 知っておくべきことは次のとおりです:
+
+<!--
 *   Make sure you have a strong password: it should be long, random, and stored in the password manager of your choice.
     *   Bad: X\*7z7XL{kZvky7E(
     *   Good: aLy%t;67zvy3VdFwVPKA@VGV?i7oq.63Lj.2aKZ@Tw3\].Eu4kVUJJVGyXH7oRL\*a
@@ -11,9 +20,25 @@ Welcome to being a committer! Here are some things you should know:
 *   Read through [this guide on commit messages](https://make.wordpress.org/core/handbook/best-practices/commit-messages/) for a primer on what’s considered best practices.
 *   Please ask a relevant committer to peer-review your first few prospective patches and commit messages before you commit them. This serves as a safety check to make sure you know what to look out for before you actually commit. It also gives you a chance to ask any questions you have about process, standards, norms, etc.
 *   It can also be a good idea to ask for peer-review from another committer whenever you have any doubts about a patch, especially if you’re committing outside an area that you normally work on.
+-->
 
+*   強力なパスワードを設定すること: パスワードは長く、ランダムで、好みのパスワード・マネージャーに保存すること。
+    *   悪い: X\*7z7XL{kZvky7E(
+    *   良い: aLy%t;67zvy3VdFwVPKA@VGV?i7oq.63Lj.2aKZ@Tw3\].Eu4kVUJJVGyXH7oRL\*a
+*   GitHub、Slack、そして w.org アカウントに関連するメールアカウントで、二要素認証が有効になっていることを確認してください。また、ハッカーは優先度の低いアカウントへのアクセスを利用して優先度の高いアカウントにアクセスすることが多いため、使用するサービスに対してこれを有効にすることも非常に良い考えです。
+*   Slack の[#core](https://make.wordpress.org/core/tag/core/)-committers チャンネルに参加してください。このチャンネルは、コミットのオンボーディングと、コミットすること、SVN のコツやヒントなどに関するコミッターからの質問のためのものです。コミットに関する質問 (例: SVN の構文、バックポートなど) があればいつでも歓迎しますし、ここで質問することを推奨します。非コミッターに関連すること (たとえば、パッチがコミット可能かどうか、プロジェクトの理念、提案など) は、他の貢献者の邪魔をしないように、[#core](https://make.wordpress.org/core/tag/core/) で行われるべきです。
+*   あなたの GitHub アカウントに `svnusername@git.wordpress.org` (例: `pento@git.wordpress.org`) を追加してください: https://github.com/settings/emails。こうすることで、新しい GitHub ミラー(https://github.com/WordPress/wordpress-develop)であなたのコミットの属性が正しく表示されます。GitHub は認証メールを送ろうとしますが、届きません。コミット属性のためにこのメールアドレスを確認する必要はありません。
+*   ベストプラクティスと考えられるものについての入門として、[コミットメッセージに関するこのガイド](https://make.wordpress.org/core/handbook/best-practices/commit-messages/)を読んでください。
+*   最初のいくつかのパッチやコミットメッセージをコミットする前に、関連するコミッターに査読を依頼してください。これは実際にコミットする前に、何に注意すべきかを確認するための安全なチェックとして機能します。また、プロセスや標準、規範などに関して質問があれば質問する機会にもなります。
+*   また、パッチについて疑問があるときは、特に普段取り組んでいる分野以外のパッチをコミットする場合は、別のコミッターに査読を依頼することも良いでしょう。
+
+<!--
 ## Tasks to add a committer
+-->
 
+## コミッターを追加するタスク
+
+<!--
 *   Ensure the committer has completed the above steps.
 *   On a WordPress.org Sandbox, add them to the following lists:
     *   `/home/svn/etc/develop.svn.wordpress.org` in Deploy SVN
@@ -24,3 +49,15 @@ Welcome to being a committer! Here are some things you should know:
     *   The [WordPress Core Team](https://github.com/orgs/WordPress/teams/wordpress-core) on GitHub
     *   The Committer group on [Core Trac](https://core.trac.wordpress.org/admin)
 *   If the committer will be working on security issues, refer to the Security Team handbook for onboarding tasks.
+-->
+
+*   コミッターが上記のステップを完了したことを確認する。
+*   WordPress.org サンドボックス上で、以下のリストに追加する:
+    *   デプロイ SVN の `/home/svn/etc/develop.svn.wordpress.org`
+    *   `.config/capes.php` の `$committers`
+    *   [Trac SVN](https://meta.svn.wordpress.org/sites/trunk/trac.wordpress.org) の `templates/core/site-specific.html` ファイルの中の `wpTracContributorLabels`
+*   さらに、以下のグループに追加する:
+    *   WordPress Slack の コアコミッターのユーザーグループ
+    *   GitHub の [WordPress Core Team](https://github.com/orgs/WordPress/teams/wordpress-core)
+    *   [Core Trac](https://core.trac.wordpress.org/admin) のコミッターグループ
+*   コミッターがセキュリティ問題に取り組む場合は、セキュリティチームのハンドブックを参照して、オンボーディングタスクに取り組んでください。


### PR DESCRIPTION
Closes: #148

- 日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/2232a5a0fde5b06fcb325cc5a9db23151bb85dc1/core/best-practices/when-you-become-a-committer.md
- 英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/best-practices/when-you-become-a-committer.md
- 英語 Web ページ: https://make.wordpress.org/core/handbook/best-practices/when-you-become-a-committer/

Note: このページで言う「コミッター」とは、他のページのような「コードで貢献するコミッター全般」の事ではなく「WordPresコアの SVN に直接コミット出来る権限を持つコミッター」の事だと思います。