### PR TITLE
translate/best-practices/spelling.md

### DIFF
--- a/core/best-practices/spelling.md
+++ b/core/best-practices/spelling.md
@@ -1,10 +1,22 @@
+<!--
 # Spelling
+-->
 
+# スペリング
+
+<!--
 ## Terminology
+-->
 
+## 用語
+
+<!--
 The following conventions of spelling and terminology apply to the manuals, web pages, comments, and (except where they require spaces or hyphens to be used) function and variable names, although consistency in user-visible documentation and diagnostics is more important than that in comments and code. Also don’t forget that the [Code Reference](https://developer.wordpress.org/reference/) is auto-generated from the code. The following table lists some simple cases:
+-->
 
-| Use… | …instead of | Notes |
+次のスペリングと用語の規則は、マニュアル、Web ページ、コメント、(スペースやハイフンの使用が必要な場合を除く) 関数名と変数名に適用されます。ただし、ユーザーに表示されるドキュメントの一貫性は、コメントやコードの一貫性よりも重要です。[コードリファレンス](https://developer.wordpress.org/reference/)がコードから自動生成されることも忘れないでください。次の表に、いくつかの単純なケースを示します。
+
+<!-- | Use… | …instead of | Notes |
 | --- | --- | --- |
 | American spelling (in particular -ize, -or) | British spelling (in particular -ise, -our) |   |
 | “a user” or “a URL” | “an user” or “an URL” | [#31894](https://core.trac.wordpress.org/ticket/31894), [#36218](https://core.trac.wordpress.org/ticket/36218) |
@@ -28,31 +40,91 @@ The following conventions of spelling and terminology apply to the manuals, web
 | “front-end” (adjective) | “front end” or “frontend” | [](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[#34887](https://core.trac.wordpress.org/ticket/34887) |
 | “full site editing” | “Full Site Editing” or “full-site editing” |  |
 | “homepage” (noun) | “home page” | [#41828](https://core.trac.wordpress.org/ticket/41828) |
-| “installation” (noun) | “install” | The word “install” is not a noun. When referring to an instance of WordPress, the correct word to use is “installation”.  
+| “installation” (noun) | “install” | The word “install” is not a noun. When referring to an instance of WordPress, the correct word to use is “installation”.
 [#41620](https://core.trac.wordpress.org/ticket/41620) |
 | “JavaScript” | “Javascript” or “javascript” | [#30569](https://core.trac.wordpress.org/ticket/30569) |
-| “log in” (verb) | “login” | The word “login” is not a verb. When referring to the action of logging in, the correct phrase to use is “log in”.  
+| “log in” (verb) | “login” | The word “login” is not a verb. When referring to the action of logging in, the correct phrase to use is “log in”.
 [#18294](https://core.trac.wordpress.org/ticket/18294) |
 | “meta box” | “metabox” |   |
 | “oEmbed” | “embed” |   |
 | “Paragraph block” | “Paragraph Block” or “paragraph block” | When referring to blocks capitalize the block name and keep ‘block’ lowercase. [github#16118](https://github.com/WordPress/gutenberg/issues/16118#issuecomment-501458511) |
 | “retrieve” | “retreive” or “retrive” | “retreive” or “retrive” aren’t words, [\[2465\]](https://core.trac.wordpress.org/changeset/2465) |
 | “term meta” | “termmeta” |   |
-| “WordPress” | “WP” | “WordPress” is preferred when referring to the CMS, project, or community.  One exception is when referencing a specific version, e.g. “WP 5.0”, or where the trademark rules prohibit the use of “WordPress”. |
+| “WordPress” | “WP” | “WordPress” is preferred when referring to the CMS, project, or community.  One exception is when referencing a specific version, e.g. “WP 5.0”, or where the trademark rules prohibit the use of “WordPress”. | -->
 
+| これらを使用する | これらの代わりに | 注記 |
+| --- | --- | --- |
+| アメリカのスペル (特に -ize、-or) | イギリスのスペリング (特に -ise、-our) |   |
+| 「a user」または「a URL」 | 「an user」または「an URL」 | [#31894](https://core.trac.wordpress.org/ticket/31894), [#36218](https://core.trac.wordpress.org/ticket/36218) |
+| 「Ajax」 | 「ajax」または「AJAX」 | 「\[Ajax\] という名前は、Asynchronous JavaScript + XML の略称であり、Web でできることの根本的な変化を表しています。」([ソース](http://adaptivepath.org/ideas/ajax-new-approach-web-applications/)) |
+| 「allowed list」、「allowed」、「permitted」 | 「whitelist」 | 「Whitelist」は人種差別的とみなされる可能性があり、またあいまいです。提案された代替案のいずれかを使うか、実際に許可されていることをより明確に記述するように言い換えてみてください。|
+| 「Auto-update」または「auto-update」 | 「auto update」または「autoupdate」 |   |
+| 「back end」(名詞) | 「back-end」または「backend」 | [](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[#34887](https://core.trac.wordpress.org/ticket/34887) |
+| 「back-end」(形容詞) | 「back end」または「backend」 | [](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[#34887](https://core.trac.wordpress.org/ticket/34887) |
+| 「backward compatibility」または「back-compat」 | 「backwards compatibility」または「backwards compat」 | [#36835](https://core.trac.wordpress.org/ticket/36835) |
+| 「block list」、「disallowed list」、「disallowed」 | 「blacklist」 | 「Blacklist」は人種差別的とみなされる可能性があり、またあいまいです。提案された代替案のいずれかを使うか、実際にブロックされていることをより明確に記述するように言い換えてみてください。 |
+| 「block editor」または「block-based editor」 | 「Block Editor」または「Gutenberg」 | 新しいエディターを指す場合。 |
+| 「block theme」 | 「block-based theme」 |  |
+| 「Classic Editor」 | 「classic editor」 | [Classic Editor プラグイン](https://wordpress.org/plugins/classic-editor/)を指す場合。 |
+| 「classic editor」 | 「Classic Editor」 | プラグインではなく、クラシックエディターのインターフェイスを指す場合。 |
+| 「visual editor」 | 「Visual Editor」 | ビジュアルエディターインターフェイスを指す場合。|
+| 「code editor」 | 「Code Editor」 | コードエディターインターフェイスを指す場合。|
+| 「Customizer」 | 「Theme Customizer」または「customizer」 | カスタマイザーは、必ずしもテーマ固有のものではありません。[#29947](https://core.trac.wordpress.org/ticket/29947) |
+| 「Dark Mode」 | 「dark mode」または「dark-mode」 | [Twenty Twenty-One #855](https://github.com/WordPress/twentytwentyone/pull/855) |
+| 「email」 | 「e-mail」 | [#26156](https://core.trac.wordpress.org/ticket/26156) |
+| 「front end」(名詞) | 「front-end」または「frontend」 | [](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[#34887](https://core.trac.wordpress.org/ticket/34887) |
+| 「front-end」(形容詞) | 「front end」または「frontend」 | [](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[](https://core.trac.wordpress.org/ticket/34887)[#34887](https://core.trac.wordpress.org/ticket/34887) |
+| 「full site editing」 | 「Full Site Editing」または「full-site editing」 |  |
+| 「homepage」(名詞) | 「home page」 | [#41828](https://core.trac.wordpress.org/ticket/41828) |
+| 「installation」(名詞) | 「install」 | 「インストール」は名詞ではありません。WordPress のインスタンスを指す場合、「インストール」という言葉を使うことが正しいです。[#41620](https://core.trac.wordpress.org/ticket/41620) |
+| 「JavaScript」 | 「Javascript」または「javascript」 | [#30569](https://core.trac.wordpress.org/ticket/30569) |
+| 「log in」 (動詞) | 「login」 | 「ログイン」は動詞ではありません。ログインする動作を指す場合は、「log in」が正しい表現です。[#18294](https://core.trac.wordpress.org/ticket/18294) |
+| 「meta box」 | 「metabox」 |   |
+| 「oEmbed」 | 「embed」 |   |
+| 「Paragraph block」 | 「Paragraph Block」または「paragraph block」 | ブロックを参照する場合は、ブロック名を大文字にし、「block」を小文字のままにしてください。 [github#16118](https://github.com/WordPress/gutenberg/issues/16118#issuecomment-501458511) |
+| 「retrieve」 | 「retreive」または「retrive」 | 「retreive」や「retrive」は単語ではありません。 [\[2465\]](https://core.trac.wordpress.org/changeset/2465) |
+| 「term meta」 | 「termmeta」 |   |
+| 「WordPress」 | 「WP」 | CMS、プロジェクト、コミュニティについて言及する場合は、「WordPress」が好まれます。例外として、「WP 5.0」のように特定のバージョンに言及する場合や、商標規則で「WordPress」の使用が禁止されている場合があります。|
+
+<!--
 Inspired by the [GCC Coding Convention](https://gcc.gnu.org/codingconventions.html#Spelling).
+-->
 
+[GCC Coding Convention](https://gcc.gnu.org/codingconventions.html#Spelling) にインスパイアされています。
+
+<!--
 ## Capitalization
+-->
+
+## キャピタライゼーション
 
 *   Labels
 *   Button labels
 *   Actions
 
+<!--
 ## Abbreviations and Acronyms
+-->
 
+## 略語と頭字語
+
+<!--
 Use abbreviations and acronyms only when they are familiar.
+-->
 
+略語や頭字語は、よく知られている場合にのみ使用してください。
+
+<!--
 ## Quotation marks
+-->
 
-In DocBlock comments use the *straight* sin­gle quote (`'`) or the straight dou­ble quote (`"`). In strings, which are visible to users, use *curly* quotes: The open­ing sin­gle quote (`‘`), the clos­ing sin­gle quote (`’`), the open­ing dou­ble quote (`“`), and the clos­ing dou­ble quote (`”`).  
+## 引用符
+
+<!--
+In DocBlock comments use the *straight* sin­gle quote (`'`) or the straight dou­ble quote (`"`). In strings, which are visible to users, use *curly* quotes: The open­ing sin­gle quote (`‘`), the clos­ing sin­gle quote (`’`), the open­ing dou­ble quote (`“`), and the clos­ing dou­ble quote (`”`).
 See also [Butterick’s Practical Typography](http://practicaltypography.com/straight-and-curly-quotes.html).
+-->
+
+DocBlock のコメントでは、「まっすぐな」シングルクオート (`'`) またはストレートダブルクオート (`"`) を使用します。ユーザーから見える文字列では、「まがった」クオートを使います: 開始シングルクオートは (`'`)、終了シングルクオートは (`'`)、開始ダブルクオートは (`"`)、終了ダブルクオートは (`"`) です。
+
+[Butterick's Practical Typography](http://practicaltypography.com/straight-and-curly-quotes.html) も参照してください。


### PR DESCRIPTION
Closes #179

- 日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/ae1e46546449e16b04a7787268942bb3ab9b609e/core/best-practices/spelling.md
- 英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/best-practices/spelling.md
- 英語 Web ページ: https://make.wordpress.org/core/handbook/best-practices/spelling/

Note: 表の部分に関しては、[実際に翻訳されたGitHubのREADMEページ](https://github.com/jawordpressorg/core-handbook/blob/ae1e46546449e16b04a7787268942bb3ab9b609e/core/best-practices/spelling.md#%E7%94%A8%E8%AA%9E)を見ていただくと分かりやすいかもしれません。