### PR TITLE
コーディング規約ハンドブック関連ページの翻訳

### DIFF
--- a/core/best-practices/coding-standards.md
+++ b/core/best-practices/coding-standards.md
@@ -1,5 +1,12 @@
+<!--
 # WordPress Coding Standards
+-->
 
+# WordPress コーディング規約
+
+注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/wordpress-coding-standards/)に移動されました。
+
+<!--
 The purpose of the WordPress Coding Standards is to create a baseline for collaboration and review within various aspects of the WordPress open source project and community, from core code to themes to plugins.
 
 The WordPress community developed the standards contained in this section of the handbook, and those standards are part of the best practices that developers and core contributors are recommended to follow.
@@ -22,3 +29,4 @@ If you are planning to contribute to WordPress core, you need to familiarize you
 ## Accessibility Standards
 
 WordPress is committed to meeting the [Web Content Accessibility Guidelines (WCAG) at level AA](https://www.w3.org/TR/WCAG20/) for all new and updated code. We’ve provided a section with [accessibility best practices](https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/) you should be aware of when creating patches or feature plug-ins.
+-->

--- a/core/best-practices/coding-standards/accessibility-coding-standards.md
+++ b/core/best-practices/coding-standards/accessibility-coding-standards.md
@@ -1,8 +1,17 @@
+<!--
 # Accessibility Coding Standards
+-->
 
+# アクセシビリティコーディング規約
+
+<!--
 Warning: This page has been moved [here](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/)
 Please do *not* edit this page.
+-->
 
+注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/wordpress-coding-standards/accessibility/)に移動されました。
+
+<!--
 These are standards that WordPress features should meet for accessibility in order to be merged into core. All new or updated code released in WordPress must conform with the WCAG 2.0 guidelines at level AA. These basic guidelines are intended for easy reference during development, but do not cover all possible accessibility issues.
 
 In the [Accessibility Handbook](https://make.wordpress.org/accessibility/handbook/best-practices/) there are pages about best practices, including code examples and resources.
@@ -88,3 +97,4 @@ Existing code uses a mixture of explicitly and implicitly labeled fields, but al
 Don’t introduce new title attributes to convey information. Use aria-label when you need to provide an alternate label and `.screen-reader-text` if you’re appending additional data.
 
 When creating forms, use `<fieldset>` and `<legend>` to group logically related form elements inside complex forms or to group radio buttons and checkboxes under a heading.
+-->

--- a/core/best-practices/coding-standards/css.md
+++ b/core/best-practices/coding-standards/css.md
@@ -1,8 +1,17 @@
+<!--
 # CSS Coding Standards
+-->
 
+# CSS コーディング規約
+
+<!--
 Warning: This page has been moved [here](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/)
 Please do *not* edit this page, use *edit* on the new page.
+-->
 
+注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/wordpress-coding-standards/css/)に移動されました。
+
+<!--
 Like any coding standard, the purpose of the WordPress CSS Coding Standards is to create a baseline for collaboration and review within various aspects of the WordPress open source project and community, from core code to themes to plugins. Files within a project should appear as though created by a single entity. Above all else, create code that is readable, meaningful, consistent, and beautiful.
 
 Within core stylesheets, inconsistencies will often be found. We are working on addressing these and make every effort to have patches and commits from this point forward follow the CSS coding standards. More information on the above and contributing to UI/front-end development will be forthcoming in a separate set of guidelines.
@@ -298,3 +307,4 @@ Stylesheets tend to get long in length. Focus slowly gets lost whilst intended g
 ## Related Links
 
 *   Principles of writing consistent, idiomatic CSS: [https://github.com/necolas/idiomatic-css](https://github.com/necolas/idiomatic-css)
+-->

--- a/core/best-practices/coding-standards/html.md
+++ b/core/best-practices/coding-standards/html.md
@@ -1,8 +1,17 @@
+<!--
 # HTML Coding Standards
+-->
 
+# HTML コーディング規約
+
+<!--
 Warning: This page has been moved [here](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/)
 Please do *not* edit this page.
+-->
 
+注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/wordpress-coding-standards/html/)に移動されました。
+
+<!--
 ## HTML
 
 ### Validation
@@ -101,3 +110,4 @@ Incorrect:
 ## Credits
 
 *   HTML code standards adapted from [Fellowship Tech Code Standards](http://developer.fellowshipone.com/patterns/code.php) ([CC license](http://creativecommons.org/licenses/by-nc-sa/3.0/)).
+-->

--- a/core/best-practices/coding-standards/javascript.md
+++ b/core/best-practices/coding-standards/javascript.md
@@ -1,8 +1,17 @@
+<!--
 # JavaScript Coding Standards
+-->
 
+# JavaScript コーディング規約
+
+<!--
 Warning: This page has been moved [here](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/)
 Please do *not* edit this page.
+-->
 
+注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/wordpress-coding-standards/javascript/)に移動されました。
+
+<!--
 JavaScript has become a critical component in developing WordPress-based applications (themes and plugins) as well as WordPress core. Standards are needed for formatting and styling JavaScript code to maintain the same code consistency as the WordPress standards provide for core PHP, HTML, and CSS code.
 
 > All code in any code-base should look like a single person typed it, no matter how many people contributed. – [Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwaldron/idiomatic.js/)
@@ -601,3 +610,4 @@ if ( typeof jQuery.fn.hoverIntent === 'undefined' ) {
 ## Credits
 
 *   The jQuery examples are adapted from the [jQuery JavaScript Style Guide](https://contribute.jquery.org/style-guide/js), which is made available under the MIT license.
+-->

--- a/core/best-practices/coding-standards/php.md
+++ b/core/best-practices/coding-standards/php.md
@@ -1,8 +1,13 @@
 # PHP Coding Standards
 
+<!--
 Warning: This page has been moved [here](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)
 Please do *not* edit this page, use *edit* on the new page.
+-->
 
+注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/wordpress-coding-standards/php/)に移動されました。
+
+<!--
 Some parts of the WordPress code structure for PHP markup are inconsistent in their style. WordPress is working to gradually improve this by helping users maintain a consistent style so the code can become clean and easy to read at a glance.
 
 Keep the following points in mind when writing PHP code for WordPress, whether for core programming code, plugins, or themes. The guidelines are similar to [Pear standards](http://pear.php.net/manual/en/standards.php) in many ways, but differ in some key respects.
@@ -121,7 +126,6 @@ Note that requiring the use of braces just means that *single-statement inline c
 	<div class="hfeed">
 		<?php while ( have_posts() ) : the_post(); ?>
 			<article id="post-<?php the_ID() ?>" class="<?php post_class() ?>">
-				<!-- ... -->
 			</article>
 		<?php endwhile; ?>
 	</div>
@@ -578,3 +582,4 @@ Per [#22400](https://core.trac.wordpress.org/ticket/22400 "Remove all, or at le
 *   June 20, 2014: Add [section](#error-control-operator) to discourage use of the [error control operator](http://www.php.net//manual/en/language.operators.errorcontrol.php) (`@`). See [#wordpress-dev](https://irclogs.wordpress.org/chanlog.php?channel=wordpress-dev&day=2014-06-20&sort=asc#m873356).
 *   October 20, 2014: Update brace usage to indicate that the alternate syntax for control structures is allowed, even encouraged. It is single-line inline control structures that are forbidden.
 *   January 21, 2014: Add section to forbid extract().
+-->

--- a/core/best-practices/inline-documentation-standards.md
+++ b/core/best-practices/inline-documentation-standards.md
@@ -1,9 +1,16 @@
+<!--
 # Inline Documentation Standards
+-->
 
+# WordPress インラインドキュメント規約
+
+注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/inline-documentation-standards/)に移動されました。
+
+<!--
 Inline documentation provides a good resource for core developers in future development, and other developers when learning about WordPress. It also provides the information necessary to populate the [WordPress developer code reference](https://developer.wordpress.org/reference/).
 
 > **I don’t need to document my code. I wrote all of it – know it like the back of my hand.**
-> 
+>
 > “I would argue that, separately, documentation *is also* for you, the developer. I’ve found quite often that my inline documentation can be a very effective breadcrumb trail when establishing one’s own intent, particularly with regard to complex function arguments and usage. And it’s also helpful to return to a function two years later and find a paragraph in the inline documentation that describes, in meticulous fashion, something that I otherwise would have had to rediscover all over again.” *– Nacin*
 
 ## Language-specific Standards
@@ -14,3 +21,4 @@ Inline documentation provides a good resource for core developers in future deve
 ## Resources
 
 *   [Inline documentation](http://jaco.by/2012/06/04/inline-documentation/) – why you should
+-->

--- a/core/best-practices/inline-documentation-standards/javascript.md
+++ b/core/best-practices/inline-documentation-standards/javascript.md
@@ -1,8 +1,17 @@
+<!--
 # JavaScript Documentation Standards
+-->
 
+# JavaScript ドキュメント規約
+
+<!--
 Warning: This page has been moved [here](https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/)
 Please do *not* edit this page, use *edit* on the new page.
+-->
 
+注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/inline-documentation-standards/javascript/)に移動されました。
+
+<!--
 WordPress follows the [JSDoc 3 standard](http://usejsdoc.org/) for inline JavaScript documentation.
 
 ## What Should Be Documented
@@ -461,3 +470,4 @@ WordPress uses JSHint for general code quality testing. Any inline configuration
 | [@prop](https://profiles.wordpress.org/prop/) | An unsupported synonym. Use property instead. |
 | [@returns](https://profiles.wordpress.org/returns/) | An unsupported synonym. Use return instead. |
 | [@exception](https://profiles.wordpress.org/exception/) | An unsupported synonym. Use [@throws](https://profiles.wordpress.org/throws/) instead. |
+-->

--- a/core/best-practices/inline-documentation-standards/php.md
+++ b/core/best-practices/inline-documentation-standards/php.md
@@ -1,8 +1,17 @@
+<!--
 # PHP Documentation Standards
+-->
 
+# PHP ドキュメント規約
+
+<!--
 Warning: This page has been moved [here](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)
 Please do *not* edit this page, use *edit* on the new page.
+-->
 
+注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/inline-documentation-standards/php/)に移動されました。
+
+<!--
 WordPress uses a customized documentation schema that draws inspiration from PHPDoc, an evolving standard for providing documentation to PHP code, which is maintained by [phpDocumentor](http://phpdoc.org/).
 
 In some special cases – such as WordPress’ implementation of hash notations – standards are derived from the [draft PSR-5 recommendations](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md). This does not mean we are attempting to be “PSR-5 compliant” at this time, it simply means that we’ve adopted PSR-5 recommendations *in part*.
@@ -631,3 +640,4 @@ The `@copyright` and `@license` tags are used in external libraries and scripts,
 *   [phpDocumentor](http://www.phpdoc.org/)
 *   [phpDocumentor Tutorial Tags](http://manual.phpdoc.org/HTMLSmartyConverter/HandS/phpDocumentor/tutorial_tags.pkg.html)
 *   [Draft PSR-5 recommendations](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md)
+-->


### PR DESCRIPTION
コーディング規約関連の9ページについて、以下の対応を行いました。

- 原文を全てコメントアウト
- タイトルのみを翻訳
- 「 `注意: このページは[こちら](https://ja.wordpress.org/team/handbook/coding-standards/XXXX)に移動されました。`」という日本語テキストを追加

### 日本語化された対象ページ

- https://github.com/jawordpressorg/core-handbook/blob/remove-unnecessary-pages/core/best-practices/coding-standards.md
- https://github.com/jawordpressorg/core-handbook/blob/remove-unnecessary-pages/core/best-practices/coding-standards/accessibility-coding-standards.md
- https://github.com/jawordpressorg/core-handbook/blob/remove-unnecessary-pages/core/best-practices/coding-standards/css.md
- https://github.com/jawordpressorg/core-handbook/blob/remove-unnecessary-pages/core/best-practices/coding-standards/html.md
- https://github.com/jawordpressorg/core-handbook/blob/remove-unnecessary-pages/core/best-practices/coding-standards/javascript.md
- https://github.com/jawordpressorg/core-handbook/blob/remove-unnecessary-pages/core/best-practices/coding-standards/php.md
- https://github.com/jawordpressorg/core-handbook/blob/remove-unnecessary-pages/core/best-practices/inline-documentation-standards.md
- https://github.com/jawordpressorg/core-handbook/blob/remove-unnecessary-pages/core/best-practices/inline-documentation-standards/javascript.md
- https://github.com/jawordpressorg/core-handbook/blob/remove-unnecessary-pages/core/best-practices/inline-documentation-standards/php.md

### 背景

これらのページは、コアハンドブックの原文にも存在するものの、実際には [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/) の各ページにリダイレクトされています。

これらのページは全て日本語翻訳が完了していて、[WordPress コーディング規約ハンドブック](https://ja.wordpress.org/team/handbook/coding-standards/)として存在しており、またリポジトリ自体も別（[wpcs-docs](https://github.com/jawordpressorg/wpcs-docs)）で管理されています。

そのため、このリポジトリ（core-handbook）では新たに翻訳する必要はありませんが、今後原文と同期する時の事を考慮すると単純に削除する事はできません（削除しても、原文と同期するとおそらくページが復活する）。

日本語コアハンドブック公開時にもこれらのページは作成しますが、あくまで左サイドバーの目次に表示するため、またそのページにアクセスした時にコーディング規約ハンドブックに誘導するための対応です。