### PR TITLE
translate/core/testing/automated-testing/phpunit.md

### DIFF
--- a/core/testing/automated-testing/phpunit.md
+++ b/core/testing/automated-testing/phpunit.md
@@ -582,7 +582,7 @@ Additionally, you can `npm run grunt phpunit` and run PHPUnit tests, including t
 Rather than having to switch to a terminal and manually run a test group repeatedly while working on a patch, you can keep it running continuously. Whenever you save any file, the group will run again automatically. This lets you instantly know when a change you’ve made breaks a test, or causes it to pass.
 -->
 
-パッチの作業中にターミナルに切り替えて主導でテストグループを繰り返し実行するのではなく、継続的に実行し続けることができます。ファイルを保存するたびに、テストグループは自動的に再実行されます。これにより、ある変更によってテストが壊れたり合格したりしたことをすぐに知ることができます。
+パッチの作業中にターミナルに切り替えて手動でテストグループを繰り返し実行するのではなく、継続的に実行し続けることができます。ファイルを保存するたびに、テストグループは自動的に再実行されます。これにより、ある変更によってテストが壊れたり合格したりしたことをすぐに知ることができます。
 
 <!--
 To run PHPUnit tests *and* all other watch tasks, use:

--- a/core/testing/automated-testing/phpunit.md
+++ b/core/testing/automated-testing/phpunit.md
@@ -1,63 +1,156 @@
 # PHP: PHPUnit
 
+<!--
 PHPUnit is the official testing framework chosen by the core team to test our PHP code.
+-->
 
+PHPUnit は、PHP コードをテストするためにコアチームが選んだ公式のテストフレームワークです。
+
+<!--
 ## Setup
+-->
 
+## セットアップ
+
+<!--
 **Step 1: Check out the test repository.**
+-->
 
+### ステップ1: テストリポジトリをチェックアウトする
+
+<!--
 The WordPress tests live in the core development repository, available via SVN at:
+-->
+
+WordPress のテストは、SVN 経由で利用可能なコア開発リポジトリにあります:
 
 ```bash
 svn co https://develop.svn.wordpress.org/trunk/ wordpress-develop
 cd wordpress-develop
 ```
 
+<!--
 Or Git:
+-->
+
+または Git で:
 
 ```bash
 git clone git://develop.git.wordpress.org/ wordpress-develop
 cd wordpress-develop
 ```
 
+<!--
 **Step 2: Set up a config file.**
+-->
 
+### ステップ2: config ファイルを設定する
+
+<!--
 Copy `wp-tests-config-sample.php` to `wp-tests-config.php`, and enter your database credentials. *Use a separate database.*
+-->
 
+`wp-tests-config-sample.php` を `wp-tests-config.php` にコピーし、データベースの認証情報を入力します。**別のデータベースを使用してください。**
+
+<!--
 ### Test running workflow options
+-->
 
+## テストを実行するためのワークフローオプション
+
+<!--
 There are several different ways of running the PHPUnit tests. It’s up to you to choose whichever workflow suits you best.
+-->
 
+PHPUnit テストを実行するには、いくつかの方法があります。どのワークフローを選択するかはあなた次第です。
+
+<!--
 Some workflows require more set-up than others, when in doubt, we recommend you start with the Docker workflow as that will do most setup for you.
+-->
 
+ワークフローによってはより多くの設定が必要なものがあります。迷った場合は、ほとんどのセットアップが自動的に行われる Docker ワークフローから始めることをおすすめします。
+
+<!--
 1.  Docker container
 2.  Composer
 3.  PHPUnit PHAR file with Composer available
 4.  PHPUnit PHAR file without Composer
+-->
 
+1.  Docker コンテナ
+2.  Composer
+3.  PHPUnit PHAR ファイルを Composer で実行する
+4.  Composer を使わずに PHPUnit PHAR ファイルを実行する
+
+<!--
 Note:
+-->
 
+<!--
 **Pre-requisite for non-Docker workflows:**
+-->
 
+### Docker 以外のワークフローに必要な前提条件
+
+<!--
 For non-Docker workflows, you need to make sure that PHP and MySQL/MariaDB are available.
+-->
 
+Docker 以外のワークフローでは、PHP と MySQL/MariaDB が利用可能であることを確認する必要があります。
+
+<!--
 For more information on setting up PHP and a database locally, please see the [Installing a local server](https://make.wordpress.org/core/handbook/tutorials/installing-a-local-server/) handbook pages.
+-->
 
+PHP とデータベースをローカルにセットアップする方法については、[ローカルサーバーのインストール](https://make.wordpress.org/core/handbook/tutorials/installing-a-local-server/)についてのハンドブックページを参照してください。
+
+<!--
 Please note that both [PHPUnit](https://docs.phpunit.de/en/9.6/installation.html#requirements), as well as the WordPress test suite have requirements for [certain PHP extensions](https://make.wordpress.org/hosting/handbook/server-environment/#php-extensions) to be enabled in your install to be able to run the full test suite.
+-->
 
+完全なテストスイートを実行するには、[PHPUnit](https://docs.phpunit.de/en/9.6/installation.html#requirements) と WordPress のテストスイートの両方で[特定の PHP 拡張モジュール](https://make.wordpress.org/hosting/handbook/server-environment/#php-extensions)を有効にする必要があることに注意してください。
+
+<!--
 Typical extensions which should be enabled are: `gd`, `mysql[i]`, `zip`, `exif`, `intl`, `mbstring`, `xml`, `xsl`.
+-->
 
+有効にしておくべき代表的な拡張機能は次の通りです: `gd`、`mysql[i]`、`zip`、`exif`、`intl`、`mbstring`、`xml`、`xsl`
+
+<!--
 Optionally, the PHP external extensions Xdebug, MemCache and Imagick should also be installed and enabled.
+-->
 
+オプションとして、PHP の外部拡張である Xdebug、MemCache および Imagick もインストールして有効にしておく必要があります。
+
+<!--
 #### Workflow 1: Setting up the Docker container environment
+-->
 
+### ワークフロー1: Docker コンテナ環境のセットアップ
+
+<!--
 **Step 1**: Install and then start [Docker](https://www.docker.com/products/docker-desktop)
+-->
 
+**ステップ1**: [Docker](https://www.docker.com/products/docker-desktop)をインストールし、起動する
+
+<!--
 **Step 2**: Install [NPM](https://nodejs.org/en/download/)
+-->
 
+**ステップ2**: [NPM](https://nodejs.org/en/download/)をインストールする
+
+<!--
 **Step 3**: Make sure you are in the root directory of where you installed WordPress
+-->
 
+**ステップ3**: WordPress をインストールしたディレクトリのルートディレクトリにいることを確認する
+
+<!--
 **Step 4**: Run from the command-line:
+-->
+
+**ステップ4**: コマンドラインから次のコマンドを実行する:
 
 ```bash
 npm install
@@ -66,63 +159,171 @@ npm run env:start
 npm run env:install
 ```
 
+<!--
 **Running the tests**
+-->
 
+#### テストの実行
+
+<!--
 Once the docker container is set up and provisioned, you can run the tests from the command-line: `npm run test:php`.
+-->
 
+docker コンテナをセットアップしてプロビジョニングされたら、コマンドラインからテストを実行できます: `npm run test:php`。
+
+<!--
 If you want to pass additional command-line arguments to PHPUnit, you will need to add an extra double-dash separator between the NPM command and the extra PHPUnit arguments to get NPM to pass them onto PHPUnit.
+-->
 
+追加のコマンドライン引数を PHPUnit に渡す場合は、NPM コマンドと追加の PHPUnit 引数の間に二重ダッシュ区切り文字を追加して、NPM がそれらを PHPUnit に渡すようにする必要があります。
+
+<!--
 #### Workflow 2: Setting up the Composer environment
+-->
 
+### ワークフロー2: Composer 環境のセットアップ
+
+<!--
 **Step 1**: Install [Composer](https://getcomposer.org/download/)
+-->
 
+**ステップ1**: [Composer](https://getcomposer.org/download/) をインストールする
+
+<!--
 **Step 2**: Make sure you are in the root directory of where you installed WordPress
+-->
 
+**ステップ2**: WordPress をインストールしたディレクトリのルートディレクトリにいることを確認する
+
+<!--
 **Step 3**: Run from the command-line: `composer update -W`
+-->
 
+**ステップ3**: コマンドラインから次のコマンドを実行する: `composer update -W`
+
+<!--
 **Running the tests**
+-->
 
+#### テストの実行
+
+<!--
 Once the Composer dependencies are installed, you can run the tests from the command-line: `vendor/bin/phpunit`.
+-->
 
+Composer の依存関係がインストールされたら、コマンドラインから次のコマンドを使用してテストを実行できます: `vendor/bin/phpunit`
+
+<!--
 #### Workflow 3: Setting up to run with the PHPUnit PHAR file with Composer available
+-->
 
+### ワークフロー3: PHPUnit PHAR ファイルを Composer で実行するための設定
+
+<!--
 **Step 1**: Install PHPUnit Phar
+-->
 
+**ステップ1**: PHPUnit Phar をインストールする
+
+<!--
 Install the PHAR which is [appropriate for your PHP version](https://phpunit.de/supported-versions.html). Installation instructions can be found in [the PHPUnit manual](https://docs.phpunit.de/en/9.6/installation.html) or on [the PHPUnit website](https://phpunit.de/getting-started/phpunit-9.html).
+-->
 
+[PHP のバージョンに適した](https://phpunit.de/supported-versions.html) PHAR をインストールします。インストール手順は、[PHPUnit のマニュアル](https://docs.phpunit.de/en/9.6/installation.html)または [PHPUnit の Web サイト](https://phpunit.de/getting-started/phpunit-9.html) を参照してください。
+
+<!--
 **Step 2**: Install [Composer](https://getcomposer.org/download/)
+-->
 
+**ステップ2**: [Composer](https://getcomposer.org/download/) をインストールする
+
+<!--
 **Step 3**: Make sure you are in the root directory of where you installed WordPress
+-->
 
+**ステップ3**: WordPress をインストールしたディレクトリのルートディレクトリにいることを確認する
+
+<!--
 **Step 4**: Install Composer dependencies
+-->
 
+**ステップ4**: Composer の依存関係をインストールする
+
+<!--
 Run from the command-line: `composer update -W`
+-->
 
+コマンドラインから次のコマンドを実行する: `composer update -W`
+
+<!--
 **Running the tests**
+-->
 
+#### テストの実行
+
+<!--
 Once the PHPUnit PHAR and the Composer dependencies are installed, you can run the tests from the command-line: `[path/to/]phpunit`.
+-->
 
+PHPUnit PHAR と Composer の依存関係がインストールされたら、コマンドラインから次のコマンドを使用してテストを実行できます: `[path/to/]phpunit`
+
+<!--
 #### Workflow 4: Setting up to run with the PHPUnit PHAR file without Composer
+-->
 
+### ワークフロー4: Composer を使わずに PHPUnit PHAR ファイルを実行するように設定する
+
+<!--
 This method is most suitable if you want to install PHPUnit and the PHPUnit Polyfills globally and run tests in multiple directories.
+-->
 
+この方法は、PHPUnit と PHPUnit ポリフィルをグローバルにインストールし、複数のディレクトリでテストを実行する場合に最適です。
+
+<!--
 **Step 1**: Install PHPUnit PHAR
+-->
 
+**ステップ1**: PHPUnit PHAR をインストールする
+
+<!--
 Install the PHAR which is [appropriate for your PHP version](https://phpunit.de/supported-versions.html). Installation instructions can be found in [the PHPUnit manual](https://docs.phpunit.de/en/9.6/installation.html) or on [the PHPUnit website](https://phpunit.de/getting-started/phpunit-9.html).
+-->
 
+[PHP のバージョンに適した](https://phpunit.de/supported-versions.html) PHAR をインストールします。インストール手順は、[PHPUnit のマニュアル](https://docs.phpunit.de/en/9.6/installation.html)または [PHPUnit の Web サイト](https://phpunit.de/getting-started/phpunit-9.html) を参照してください。
+
+<!--
 **Step 2**: Install [PHPUnit Polyfills](https://github.com/Yoast/PHPUnit-Polyfills/)
+-->
 
+**ステップ2**: [PHPUnit](https://github.com/Yoast/PHPUnit-Polyfills/) ポリフィルをインストールする
+
+<!--
 Typically, you would clone the GitHub repository:
+-->
+
+通常は、GitHub リポジトリのクローンを作成します:
 
 ```bash
 git clone git@github.com:Yoast/PHPUnit-Polyfills.git [target/path]
 ```
 
+<!--
 **Step 3**: Define path to Polyfills
+-->
 
+**ステップ3**: ポリフィルへのパスを定義する
+
+<!--
 Once the Polyfills are installed, tell the WordPress test bootstrap where to find them by passing the path via a `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant.
+-->
 
+ポリフィルをインストールしたら、定数 `WP_TESTS_PHPUNIT_POLYFILLS_PATH` でパスを定義して、Polyfills がどこにあるかを WordPress のテスト用ブートストラップに伝えます。
+
+<!--
 This constant can be declared in the `phpunit.xml[.dist]` file like this:
+-->
+
+この定数は、`phpunit.xml[.dist]` ファイルで次のように宣言します:
 
 ```php
 <php>
@@ -131,23 +332,59 @@ This constant can be declared in the `phpunit.xml[.dist]` file like this:
 
 ```
 
+<!--
 or can be declared as a PHP constant in the `wp-tests-config.php` file.
+-->
 
+または、`wp-tests-config.php` ファイルで PHP 定数として宣言できます。
+
+<!--
 **Running the tests**
+-->
 
+#### テストの実行
+
+<!--
 Once the PHPUnit PHAR and Polyfills are installed, you can run the tests from the root directory of your WordPress install via the command-line: `[path/to/]phpunit`.
+-->
 
+PHPUnit PHAR とポリフィルをインストールしたら、コマンドラインから次のコマンドを使用してテストを実行できます: `[path/to/]phpunit`
+
+<!--
 Note: If you use this workflow, please ensure you keep your local clone of the PHPUnit Polyfills up to date.
+-->
 
+備考: このワークフローを使用する場合は、PHPUnit ポリフィルのローカルクローンを常に最新の状態にしておくようにしましょう。
+
+<!--
 ## Running the Test Suite
+-->
 
+## テストスイートの実行
+
+<!--
 Note:
+-->
 
+備考:
+
+<!--
 Once you have chosen your preferred workflow and set up your machine according to the above instructions, you can run the tests via the command listed with your preferred workflow above.
+-->
 
+好みのワークフローを選び、上記の手順に従ってマシンをセットアップしたら、上記の好みのワークフローに記載されているコマンドでテストを実行できます。
+
+<!--
 All examples below will use `phpunit`. Replace this with your workflow specific command for running these examples locally.
+-->
 
+以下のすべての例では `phpunit` を使用します。これらの例をローカルで実行する場合は、このコマンドをワークフロー固有のコマンドに置き換えてください。
+
+<!--
 You should see output that looks roughly like the following:
+-->
+
+おおよそ以下のような出力が表示されるはずです:
 
 ```bash
 ...........................................................    59 / 12524 (  0%)
@@ -163,44 +400,89 @@ You should see output that looks roughly like the following:
 
 Time: 01:46.744, Memory: 235.10 MB
 
-OK, but incomplete or skipped tests! 
+OK, but incomplete or skipped tests!
 Tests: 12524, Assertions: 57712, Skipped: 56.
 
 ```
 
+<!--
 What each symbol means:
+-->
 
+各記号の意味は次の通りです:
+
+<!--
 *   `.` – Each dot signifies one “test” that passed.
 *   `S` means a test was skipped. This usually means that the test is only valid in certain configurations, such as when a test requires Multisite or a certain PHP extension.
 *   `F` means a test failed. More output will be shown for what exactly failed and where.
 *   `E` means a test failed due to a PHP error, warning, or notice.
 *   `R` means a test is marked as “risky”. What will be marked as risky, very much depends on the configuration in the `phpunit.xml.dist` file. This can be tests which are particularly slow or don’t perform assertions.
 *   `I` means a test was marked as incomplete, i.e. not yet implemented.
+-->
 
+*   `.` – それぞれのドットは合格した一つの「テスト」を意味します。
+*   `S` はテストがスキップされたことを意味します。これは通常、テストがマルチサイトや特定の PHP 拡張モジュールを必要とするなど、特定の設定でのみ有効であることを意味します。
+*   `F` はテストが失敗したことを意味します。何がどこで失敗したのか、より詳細な出力が表示されます。
+*   `E` は、PHP のエラー、警告、通知によってテストが失敗したことを意味します。
+*   `R` はテストが「危険」と判定されたことを意味します。何が危険と判定されるかは、`phpunit.xml.dist` ファイルの設定に大きく依存します。これは、特に遅いテストやアサーションを実行しないテストなどです。
+*   `I` は、テストが不完全である、たとえばまだ実装されていないことを意味します。
+
+<!--
 Note: On Windows and seeing weird codes in your command-line screen output? Try running with `--colors=never`.
+-->
 
+備考: Windows で、コマンドラインの画面出力に奇妙なコードが表示されていますか ? `--colors=never` で実行してみてください。
+
+<!--
 ### Running Specific Tests
+-->
 
+### 特定のテストの実行
+
+<!--
 #### Individual Tests
+-->
 
+#### 個別テスト
+
+<!--
 To run an **individual class**, use `--filter` with the name of the class:
+-->
+
+**個別のクラス** を実行するには、`--filter` を使用してクラス名を指定します:
 
 ```bash
 phpunit --filter Tests_Formatting_wpParseStr
 ```
 
+<!--
 The `--filter` option in PHPUnit is very flexible and has lots of supported options. Please see the [PHPUnit Manual](https://docs.phpunit.de/en/9.6/textui.html#textui-examples-filter-patterns) for more examples.
+-->
 
+PHPUnit の `--filter` オプションは非常に柔軟で、さまざまなオプションをサポートしています。[PHPUnit のマニュアル](https://docs.phpunit.de/en/9.6/textui.html#textui-examples-filter-patterns)を参照ください。
+
+<!--
 #### Groups
+-->
 
+#### グループ
+
+<!--
 To run a **group of tests** – defined by `@group` in code comments:
+-->
+
+**テストのグループ** を実行するには、コードのコメントで定義されている `@group` を使用します:
 
 ```bash
 phpunit --group dependencies
 phpunit --group themes
 ```
 
+<!--
 You may also combine groups: (Depending on your platform you may have to wrap the groups in double quotes)
+-->
+
+グループを組み合わせることもできます (プラットフォームによっては、グループを二重引用符で囲む必要がある場合があります)。
 
 ```bash
 phpunit --group shortcode,17657,6562,14050
@@ -211,98 +493,202 @@ phpunit --group shortcode,17657,6562,14050
 OK (229 tests, 417 assertions)
 ```
 
+<!--
 Note:
+-->
 
+備考:
+
+<!--
 Many tests are marked with a `@ticket` annotation, which indicates they were the result of that WordPress Trac ticket.
+-->
 
+多くのテストには `@ticket` という注釈がついており、WordPress の Trac チケットの結果であることを示しています。
+
+<!--
 The `@ticket` annotation is an alias for the `@group` annotation, so any tests linked to any individual Trac ticket can be run by passing the Trac ticket number as the “group”.
+-->
 
+`@ticket` 注釈は `@group` 注釈のエイリアスであるため、Trac チケット番号を「group」として渡すことで、個々の Trac チケットにリンクされたテストを実行できます。
+
+<!--
 To view all groups:
+-->
+
+すべてのグループを表示するには:
 
 ```bash
 phpunit --list-groups
 ```
 
+<!--
 To see information about skipped and incomplete tests, use `--verbose`:
+-->
+
+スキップされたテストや不完全なテストに関する情報を見るには、`--verbose` を使用します:
 
 ```bash
 phpunit --group wpdb --verbose
 ```
 
 ```bash
- 
-There was 1 skipped test: 
+
+There was 1 skipped test:
 1) Tests_DB::test_charset_switched_to_utf8
 This test requires utf8mb4 to not be supported.
 
 tests/phpunit/tests/db.php:1332
 ```
 
+<!--
 By default, the **AJAX tests** (tests written for core’s use of `wp-admin/admin-ajax.php`) are not run. To run these:
+-->
+
+デフォルトでは、**AJAX テスト** (コアが `wp-admin/admin-ajax.php` を使用するために作成されたテスト) は実行されません。これらを実行するには:
 
 ```bash
 phpunit --group ajax
 ```
 
+<!--
 To run the tests under **multisite**, you must switch to the `multisite.xml` configuration file:
+-->
+
+**マルチサイト**でテストを実行するには、`multisite.xml` 設定ファイルに切り替える必要があります:
 
 ```bash
 phpunit -c tests/phpunit/multisite.xml
 ```
 
+<!--
 #### With Grunt
+-->
 
+#### Grunt を使用する
+
+<!--
 Additionally, you can `npm run grunt phpunit` and run PHPUnit tests, including the ajax and multisite tests.
+-->
 
+さらに、`npm run grunt phpunit` を実行することで、ajax テストや multisite テストを含む PHPUnit テストを実行できます。
+
+<!--
 #### Running Continuously
+-->
 
+#### 継続的に実行する
+
+<!--
 Rather than having to switch to a terminal and manually run a test group repeatedly while working on a patch, you can keep it running continuously. Whenever you save any file, the group will run again automatically. This lets you instantly know when a change you’ve made breaks a test, or causes it to pass.
+-->
 
+パッチの作業中にターミナルに切り替えて主導でテストグループを繰り返し実行するのではなく、継続的に実行し続けることができます。ファイルを保存するたびに、テストグループは自動的に再実行されます。これにより、ある変更によってテストが壊れたり合格したりしたことをすぐに知ることができます。
+
+<!--
 To run PHPUnit tests *and* all other watch tasks, use:
+-->
+
+PHPUnit テスト**および**その他のすべての監視タスクを実行するには、次のようにします:
 
 ```bash
 npm run grunt watch -- --phpunit --group={testgroup}
 ```
 
+<!--
 To run *only* the PHPUnit watch task, use:
+-->
+
+PHPUnit 監視タスク**のみ**を実行するには、次のようにします:
 
 ```bash
 npm run grunt watch:phpunit -- --group={testgroup}
 ```
 
+<!--
 Run multiple groups by comma-separating them:
+-->
+
+カンマ区切りで複数のグループを実行します:
 
 ```bash
 ﻿npm run grunt watch:phpunit -- --group=community-events,privacy
 ```
 
+<!--
 #### Optimizing
+-->
 
+#### 最適化
+
+<!--
 You can speed up the suite in some cases by defining the `WP_TESTS_SKIP_INSTALL` environment variable to `1`, so that the suite will skip the install step. While this shouldn’t be used for full test runs, it’s useful for saving time when running small groups of tests.
+-->
+
+環境変数 `WP_TESTS_SKIP_INSTALL` を `1` に定義することで、スイートがインストール手順をスキップするようになり、スイートの速度を向上させることができます。これは完全なテストの実行には使用すべきではありませんが、小さなテストグループの実行時間を節約することに役立ちます。
 
 ```bash
 WP_TESTS_SKIP_INSTALL=1 phpunit --group=privacy
 ```
 
+<!--
 ## Writing Tests
+-->
 
+## テストを作成する
+
+<!--
 We’ve written [a guide](https://make.wordpress.org/core/handbook/testing/automated-testing/writing-phpunit-tests/) for getting started writing PHPUnit tests for WordPress.
+-->
 
+WordPress の PHPUnit テストを作成し始めるための[ガイド](https://make.wordpress.org/core/handbook/testing/automated-testing/writing-phpunit-tests/)を作成しました。
+
+<!--
 ## Contributing Tests to WordPress
+-->
 
+## テストで WordPress に貢献する
+
+<!--
 There are three primary ways to contribute:
+-->
 
+貢献するためには、主に3つの方法があります:
+
+<!--
 **Write tests for a reported bug.** A great way to contribute is to write tests that demonstrate an existing bug report. The core developers are reluctant to consider patches for many sensitive areas in core without test coverage. Well-written tests can help confirm that a patch fixes a problem without side effects, and can prevent any regressions from occurring in the future. When tests are particularly needed or desired for a ticket to proceed, they receive the [needs-unit-tests](https://core.trac.wordpress.org/query?keywords=~needs-unit-tests) workflow keyword. You can submit tests for existing tickets directly on the WordPress core Trac. Bonus points for submitting a bug report with a test case included.
+-->
 
+**報告されたバグのテストを作成する。** 貢献するすばらしい方法は、既存のバグ報告を実証するテストを作成することです。コア開発者は、テストカバレッジのないコアの多くの繊細な部分のパッチを検討することに消極的です。適切に作成されたテストは、パッチが副作用なしに問題を修正することを確認するのに役立ち、将来的にリグレッションが発生することを防ぐことができます。チケットを進めるためにテストが特に必要であったり望ましい場合は、[needs-unit-tests](https://core.trac.wordpress.org/query?keywords=~needs-unit-tests) ワークフローキーワードを受け取ります。既存のチケットのテストは WordPress コアの Trac で直接提出できます。テストケースを含むバグレポートを提出するとよりよいでしょう。
+
+<!--
 **Write new tests to improve our code coverage.** Many areas of WordPress do not have adequate test coverage. Pick a function, class, or component and write tests for it. You can submit these tests on [the WordPress Trac](https://core.trac.wordpress.org/).
+-->
 
+**コードカバレッジを向上させるために新しいテストを作成する。** WordPress の多くの領域で、十分なテストカバレッジを持っていません。関数、クラス、コンポーネントを選んで、そのテストを作成してください。これらのテストは [WordPress Trac](https://core.trac.wordpress.org/) で提出できます。
+
+<!--
 **Fix or improve our existing test cases.** There are many opportunities for improvement in the existing tests. Some of them are ancient and others are slow or fragile. Some do not tests well in multisite or under certain conditions. Some individual tests try to test too much, and [could be improved by using](https://docs.phpunit.de/en/9.6/writing-tests-for-phpunit.html) data providers, dependencies, and more narrow assertions.
+-->
 
+**既存のテストケースを修正または改善する。** 既存のテストには改善の余地がたくさんあります。古いものもあれば、速度が遅い、または壊れやすいものもあります。マルチサイトや特定の条件下でうまくテストできてないものもあります。一部の個別のテストより多くのことをテストしようとしており、データプロバイダ、依存関係、より限定的なアサーションを[使用することで改善できる可能性があります](https://docs.phpunit.de/en/9.6/writing-tests-for-phpunit.html)。
+
+<!--
 ## JavaScript Unit Tests
+-->
 
+## JavaScript ユニットテスト
+
+<!--
 Unit tests for JavaScript code are currently much more limited in WordPress Core in comparison to PHP unit tests. For more information on JS unit tests, see the [Make/Core post](https://make.wordpress.org/core/2013/09/13/javascript-unit-tests-for-core/ "JavaScript Unit Tests for Core") or the [QUnit section of this Handbook](https://make.wordpress.org/core/handbook/testing/automated-testing/qunit/).
+-->
 
+JavaScript コードのユニットテストは、PHP のユニットテストに比べて WordPress コアではかなり制限されています。JS ユニットテストの詳細については、[Make/Core の投稿](https://make.wordpress.org/core/2013/09/13/javascript-unit-tests-for-core/)や[ハンドブックの QUnit セクション](https://make.wordpress.org/core/handbook/testing/automated-testing/qunit/)を参照してください。
+
+<!--
 ## Further Reading
+-->
+
+## 参考資料
 
 *   [PHPUnit Manual](https://docs.phpunit.de/)
 *   [PHPUnit on Github](https://github.com/sebastianbergmann/phpunit)

--- a/core/tutorials/working-with-patches.md
+++ b/core/tutorials/working-with-patches.md
@@ -1,53 +1,130 @@
+<!--
 # Working with Patches
+-->
 
+# パッチに取り組む
+
+<!--
 This section of the handbook contains tutorials that will help you learn how to create, apply, and revert patches.
+-->
 
+ハンドブックのこのセクションには、パッチの作成、適用、およびそれらを元に戻す方法を学ぶために役立つチュートリアルが含まれています。
+
+<!--
 Patches are the only way that a contributor, like you, can submit code to the WordPress project.
+-->
 
+パッチは、あなたのような貢献者が WordPress プロジェクトにコードを提出する唯一の方法です。
+
+<!--
 Whether you are fixing a bug or contributing to a new feature, a patch is required so the core developers and committers can consider your code for inclusion in the repository.
+-->
 
+バグを修正する場合でも、新機能に貢献する場合でも、コア開発者やコミッターがあなたのコードをリポジトリに含めるかどうか検討するために、パッチが必要です。
+
+<!--
 For beta testing the latest development version of WordPress, you will need to be able to apply patches that other contributors have created to determine if the patch fixes the issue.
+-->
 
+WordPress の最新開発版をベータテストする場合、他の貢献者が作成したパッチを適用して、そのパッチが問題を修正しているかどうかを判断する必要があります。
+
+<!--
 ## SVN Client or Command Line Interface?
+-->
 
+## SVN クライアントかコマンドラインインターフェースか ?
+
+<!--
 Many developers prefer to work with Subversion (SVN) using the [command line interface](https://make.wordpress.org/core/glossary/#command-line-interface) (CLI), while others prefer to use a [GUI](http://en.wikipedia.org/wiki/GUI) application. Both are acceptable, and will allow you to create, apply, and revert patches.
+-->
 
+多くの開発者は、[コマンドラインインターフェイス](https://make.wordpress.org/core/glossary/#command-line-interface) (CLI) を使って Subversion (SVN) を操作することを好みますが、[GUI](http://en.wikipedia.org/wiki/GUI) アプリケーションを使うことを好む人もいます。どちらも問題なく、パッチの作成、適用、およびそれらを元に戻すことができます。
+
+<!--
 For command line users, there are programs such as [Cygwin](http://cygwin.com/) (Windows), [Terminal](http://en.wikipedia.org/wiki/Terminal_(OS_X)) (Mac), and [Bash](http://www.gnu.org/software/bash/) (Mac).
+-->
 
+コマンドラインユーザーには、[Cygwin](http://cygwin.com/) (Windows)、[Terminal](http://en.wikipedia.org/wiki/Terminal_(OS_X)) (Mac)、[Bash](http://www.gnu.org/software/bash/) (Mac) などのプログラムがあります。
+
+<!--
 If you prefer to use a GUI application, the recommended SVN clients are [TortoiseSVN](http://tortoisesvn.net/) (Windows, free/open-source), and [Cornerstone](http://www.zennaware.com/cornerstone/) (Mac, purchase).
+-->
 
+GUI アプリケーションを使用する場合、推奨される SVN クライアントは [TortoiseSVN](http://tortoisesvn.net/) (Windows、フリー/オープンソース)、[Cornerstone](http://www.zennaware.com/cornerstone/) (Mac、有料) です。
+
+<!--
 ## Creating and Applying Patches with Grunt
+-->
 
+## Grunt を使ったパッチの作成と適用
+
+<!--
 If you like to automatically submit the created patch to an existing ticket, there is an easy-to-use [Grunt](https://gruntjs.com/getting-started) command available that can take care of both creating the patch and uploading it. In order to use the command, you need to have [Node.js](https://nodejs.org/) and [Grunt-CLI](https://gruntjs.com/getting-started#installing-the-cli) globally installed, and you need to ensure that the WordPress development dependencies are installed locally, which you can do by running `npm install`.
+-->
 
+作成したパッチを既存のチケットに自動的に提出したい場合は、パッチの作成とアップロードの両方を行うことができる使いやすい [Grunt](https://gruntjs.com/getting-started) コマンドがあります。このコマンドを使うには、[Node.js](https://nodejs.org/) と [Grunt-CLI](https://gruntjs.com/getting-started#installing-the-cli) がグローバルにインストールされている必要があります。また、WordPress の開発依存パッケージがローカルにインストールされている必要があります。これは、`npm install` を実行することでインストールできます。
+
+<!--
 ### Apply a patch from the command line
+-->
 
+### コマンドラインからパッチを適用する
+
+<!--
 1.  Have a diff or a patch file in your working Directory, then run `grunt patch`. If multiple files are found, you’ll be asked which one to apply.
 2.  Enter a ticket number, e.g.
+-->
+
+1.  作業ディレクトリに diff かパッチファイルを用意して、`grunt patch` を実行します。複数のファイルが見つかった場合、どれを適用するか尋ねられます。
+2.  チケット番号を入力します。
 
 > `grunt patch:15705`
 
+<!--
 3.  Enter a ticket url, e.g.
+-->
+
+3.  チケットの URL を入力します。
 
 > `grunt patch:https://core.trac.wordpress.org/ticket/15705`
 
+<!--
 4.  Enter a patch url, e.g.
+-->
+
+4.  パッチの URL を入力します。
 
 > `grunt patch:https://core.trac.wordpress.org/attachment/ticket/11817/13711.diff`
 
+<!--
 5.  Enter a github url that points to a changeset such as a Pull Request, e.g.
+-->
+
+5.  プルリクエストなどのチェンジセットを指す GitHub の URL を入力します。
 
 > `grunt patch:https://github.com/muhammadfaizanhaidar/develop.wordpress/pull/23`
 
+<!--
 ### Upload a patch from the command line
+-->
 
+### コマンドラインからパッチをアップロードする
+
+<!--
 After you’ve made changes to your local WordPress develop repository, you can upload a patch file directly to a Trac ticket. e.g. given the ticket number is 2907,
+-->
+
+ローカルの WordPress 開発リポジトリに変更を加えた後、パッチファイルを Trac チケットに直接アップロードできます。たとえばチケット番号が2907であるとすると、
 
 ```
 grunt upload_patch:2907
 ```
 
+<!--
 You can also store your WordPress.org credentials in environment variables. Please exercise caution when using this option, as it may cause your credentials to be leaked!
+-->
+
+WordPress.org の認証情報を環境変数に保存することもできますが、認証情報が漏洩する可能性があるため、このオプションを使用する場合は注意してください !
 
 ```
 export WPORG_USERNAME=matt
@@ -55,168 +132,439 @@ export WPORG_PASSWORD=MyPasswordIsVerySecure12345
 grunt uploadPatch:40000
 ```
 
+<!--
 ## Creating and Applying Patches with TortoiseSVN
+-->
 
+## TortoiseSVN を使ったパッチの作成と適用
+
+<!--
 Before starting, you need:
+-->
 
+開始する前に、次のものが必要です:
+
+<!--
 *   [TortoiseSVN installed on your computer](https://make.wordpress.org/core/handbook/tutorials/installing-a-vcs/)
 *   A plain text editor, such as [Notepad++](http://notepad-plus-plus.org/), installed on your computer
+-->
 
+*   [コンピューターにインストールされた TortoiseSVN](https://make.wordpress.org/core/handbook/tutorials/installing-a-vcs/)
+*   コンピューターにインストールされた [Notepad++](http://notepad-plus-plus.org/) のようなプレーンテキストエディター
+
+<!--
 ### Creating a Patch with TortoiseSVN
+-->
 
+### TortoiseSVN でパッチを作成する
+
+<!--
 #### 1\. Editing/Saving a File
+-->
 
+#### 1\. ファイルの編集と保存
+
+<!--
 Open the folder, and find the file you need to change. Open it in your favorite plain-text editor. **Note:** Do not use a rich-text editor such as Word or OpenOffice to edit the files.
+-->
 
+フォルダーを開き、変更したいファイルを見つけてください。好きなプレーンテキストエディターで開いてください。**注意:** ファイルの編集には、Word や OpenOffice のようなリッチテキストエディターは使用しないでください。
+
+<!--
 Make the changes necessary, then save the file.
+-->
 
+必要な変更を加えて、ファイルを保存します。
+
+<!--
 You will notice that the green checkmark has changed to a red exclamation point. That means the file has been changed, and is no longer in sync with the repo version.
+-->
 
+緑色のチェックマークが赤色の感嘆符に変わっていることが分かります。これはファイルが変更され、リポジトリのバージョンと同期していないことを意味します。
+
+<!--
 ![TortoiseSVN Changed File Indicator](https://make.wordpress.org/core/files/2013/02/tortoisesvn-changed-file.png)
+-->
 
+![TortoiseSVN 変更ファイルインジケーター](https://make.wordpress.org/core/files/2013/02/tortoisesvn-changed-file.png)
+
+<!--
 #### 2\. Creating/Naming a Patch
+-->
 
+#### 2\. パッチの作成と命名
+
+<!--
 Next you will create the patch file. Right-click in the root directory of your SVN checkout folder, and select **SVN Create Patch**.
+-->
 
+次にパッチファイルを作成します。SVN チェックアウトフォルダーのルートディレクトリで右クリックし、**SVN Create Patch** を選択します。
+
+<!--
 It is important to create patches from the root directory (the folder containing all of the WordPress files). To do that, either right-click on white space in the folder or move one level up from that folder and right-click on it.
+-->
 
+ルートディレクトリ (WordPress のすべてのファイルが含まれているフォルダー) からパッチを作成することが重要です。そのためには、フォルダー内の空白を右クリックするか、そのフォルダーから1つ上の階層に移動して右クリックします。
+
+<!--
 ![TortoiseSVN Create Patch Context Menu](https://make.wordpress.org/core/files/2013/02/tortoisesvn-create-patch-1.png)
+-->
 
+![TortoiseSVN パッチを作成するコンテキストメニュー](https://make.wordpress.org/core/files/2013/02/tortoisesvn-create-patch-1.png)
+
+<!--
 A pop-up window will show you the list of changed files. Make sure the file(s) you want to include in the patch are checked, then **click OK**.
+-->
 
+ポップアップウィンドウに変更されたファイルのリストが表示されます。パッチに含めたいファイルにチェックが入っていることを確認し、**OK** をクリックします。
+
+<!--
 ![Check the box for all file(s) that should be included in the patch](https://make.wordpress.org/core/files/2013/02/tortoisesvn-create-patch-2.png)
+-->
 
+![パッチに含めたいすべてのファイルにチェックを入れる](https://make.wordpress.org/core/files/2013/02/tortoisesvn-create-patch-2.png)
+
+<!--
 You will be prompted to save the file. Create a folder called **patches**, then type in the filename you want to save it as. Use the format **ticket#.diff**.
+-->
 
+ファイルを保存するプロンプトが表示されます。**patches** というフォルダーを作成し、保存するファイル名を入力します。形式は **ticket#.diff** にしてください。
+
+<!--
 The TortoiseUDiff editor will open and show you the patch file you just created.
+-->
 
+TortoiseUDiff エディターが開き、作成したパッチファイルが表示されます。
+
+<!--
 ![TortoiseUDiff Editor](https://make.wordpress.org/core/files/2013/02/tortoisesvn-22121-patch.png)
+-->
 
+![TortoiseUDiff エディター](https://make.wordpress.org/core/files/2013/02/tortoisesvn-22121-patch.png)
+
+<!--
 ### Applying a Patch with TortoiseSVN
+-->
 
+### TortoiseSVN でパッチを適用する
+
+<!--
 Got a patch you want to test with your local environment? Follow these steps to test your patch.
+-->
 
+ローカル環境でパッチをテストしたいですか ? 以下の手順に従ってパッチをテストしてください。
+
+<!--
 #### 1\. Downloading a Patch
+-->
 
+#### 1\. パッチのダウンロード
+
+<!--
 Part of the troubleshooting/testing process involves downloading and applying patches to your local WordPress trunk install from a Trac ticket that you are involved in.
+-->
 
+トラブルシューティングやテストプロセスの一環として、あなたが関わっている Trac チケットからパッチをダウンロードして、ローカルの WordPress trunk インストールに適用することが含まれます。
+
+<!--
 To download a patch, **click on the Download icon** next to the patch filename in the **Attachments** section of the ticket (just below the **Description** section), and save it to a folder called **patches**.
+-->
 
+パッチをダウンロードするには、チケットの **Attachments** セクション (**Description** セクションのすぐ下) にあるパッチファイル名の横にある **Download アイコンをクリック**し、**patches** というフォルダーに保存してください。
+
+<!--
 ![Download A Patch From Trac Ticket Screen](https://make.wordpress.org/core/files/2013/04/tortoisesvn-apply-patch-download-file.png)
+-->
 
+![Trac チケットからパッチをダウンロードする画面](https://make.wordpress.org/core/files/2013/04/tortoisesvn-apply-patch-download-file.png)
+
+<!--
 #### 2\. Applying a Patch with TortoiseSVN
+-->
 
+#### 2\. TortoiseSVN でパッチを適用する
+
+<!--
 To apply the patch you just downloaded, **right-click in the folder** for your working copy of WordPress, which will bring up a context menu. Click on **SVN Apply Patch**.
+-->
 
+ダウンロードしたパッチを適用するために、WordPress の作業コピーの**フォルダー内で右クリック**するとコンテキストメニューが表示されます。**SVN Apply Patch** をクリックしてください。
+
+<!--
 ![TortoiseSVN Apply Patch Context Menu Screen](https://make.wordpress.org/core/files/2013/03/tortoisesvn-apply-patch-context-menu.png)
+-->
 
+![TortoiseSVN パッチを適用するコンテキストメニュー画面](https://make.wordpress.org/core/files/2013/03/tortoisesvn-apply-patch-context-menu.png)
+
+<!--
 This will bring up a file open dialog window, allowing you to select the patch file to apply. By default, only **.patch** or **.diff** files are shown, but you can change the file type to **All files** if you don’t see the patch file you are looking for.
+-->
 
+ファイルを開くダイアログウィンドウが表示され、適用するパッチファイルを選択できます。デフォルトでは、**.patch** または **.diff** ファイルだけが表示されますが、探しているパッチファイルが見つからない場合は、ファイルタイプを **すべてのファイル** に変更することができます。
+
+<!--
 ![TortoiseSVN Select Local File Screen](https://make.wordpress.org/core/files/2013/03/tortoisesvn-apply-patch-select-local-file.png)
+-->
 
+![TortoiseSVN ローカルファイルの選択画面](https://make.wordpress.org/core/files/2013/03/tortoisesvn-apply-patch-select-local-file.png)
+
+<!--
 Applying a patch file to your working copy of WordPress should be done at the same folder level as was used to create the patch. If you are in the correct working copy, but picked the wrong folder level, TortoiseSVN will display a notice, suggesting the correct level, and allows you to select that.
+-->
 
+WordPress の作業コピーにパッチファイルを適用する場合は、パッチを作成したときと同じフォルダーの階層で行ってください。正しい作業コピーであるにもかかわらず、間違ったフォルダー階層を選択した場合、TortoiseSVN は正しい階層を提案するメッセージを表示し、それを選択できるようにします。
+
+<!--
 ![TortoiseSVN Wrong Directory Screen](https://make.wordpress.org/core/files/2013/03/tortoisesvn-apply-patch-wrong-directory.png)
+-->
 
+![TortoiseSVN 誤ったディレクトリを示す画面](https://make.wordpress.org/core/files/2013/03/tortoisesvn-apply-patch-wrong-directory.png)
+
+<!--
 Once you have selected the patch file and correct working copy location, TortoiseMerge will run to merge the changes from the patch file with your working copy. A small window lists the files which have been changed. **Double-click each filename**, review the changes, and save the patched file to your working copy.
+-->
 
+パッチファイルと正しい作業コピーの場所を選択すると、TortoiseMerge が実行され、パッチファイルの変更が作業コピーにマージされます。小さなウィンドウに、変更されたファイルが一覧表示されます。**各ファイル名をダブルクリック**し、変更内容を確認し、パッチを適用したファイルを作業コピーに保存してください。
+
+<!--
 ![TortoiseSVN File Patched Screen](https://make.wordpress.org/core/files/2013/03/tortoisesvn-apply-patch-files-patched.png)
+-->
 
+![TortoiseSVN パッチが適用されたファイルを示す画面](https://make.wordpress.org/core/files/2013/03/tortoisesvn-apply-patch-files-patched.png)
+
+<!--
 ## Creating and Applying Patches with the Command Line
+-->
 
+## コマンドラインを使ったパッチの作成と適用
+
+<!--
 This article will walk you through creating, applying, and reverting a patch using the command line. Before starting, you’ll need the following:
+-->
 
+この記事では、コマンドラインを使ってパッチを作成、適用、およびそれらを元に戻す手順を説明します。はじめる前に、次のものが必要です:
+
+<!--
 *   A plain text editor, such as [Notepad++](http://notepad-plus-plus.org/) (Windows) or [TextMate](http://macromates.com/) (Mac), installed on your computer
 *   A copy of WordPress trunk, [checked out via SVN](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-svn/)
 *   A command line client installed on your computer:
     *   Windows: [Cygwin](http://cygwin.com/)
     *   MAC: [Terminal](http://en.wikipedia.org/wiki/Terminal_(OS_X)) or [Bash](http://www.gnu.org/software/bash/)
+    -->
 
+*   [Notepad++](http://notepad-plus-plus.org/) (Windows) や [TextMate](http://macromates.com/) (Mac) などのプレーンテキストエディターがコンピューターにインストールされていること
+*   [SVN 経由でチェックアウトした](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-svn/) WordPress trunk のコピー
+*   コンピューターにインストールされたコマンドラインクライアント:
+    *   Windows: [Cygwin](http://cygwin.com/)
+    *   MAC: [Terminal](http://en.wikipedia.org/wiki/Terminal_(OS_X)) または [Bash](http://www.gnu.org/software/bash/)
+
+<!--
 ### Creating a Patch with the Command Line
+-->
 
+### コマンドラインでパッチを作成する
+
+<!--
 During beta testing, you may run across a bug that you are able to fix. Before you submit the Trac ticket, however, you should create a patch with the proposed fix so you can attach it to the ticket.
+-->
 
+ベータテスト中に、あなたが修正できるバグに遭遇するかもしれません。しかし、Trac チケットを提出する前に、修正案をパッチとして作成し、チケットに添付する必要があります。
+
+<!--
 Open the folder where you have WordPress installed via SVN, and find the file you need to change. Open the file in your favorite plain-text editor. Make the changes necessary to fix the bug, then save the file. Do not create patches for minified JS files or RTL CSS files. These are generated automatically from source files. Read more about [this build process](https://make.wordpress.org/core/2013/08/06/a-new-frontier-for-core-development/).
+-->
 
+SVN 経由で WordPress がインストールされているフォルダーを開き、変更したいファイルを見つけてください。好きなプレーンテキストエディターでファイルを開いてください。バグを修正するために必要な変更を加えて、ファイルを保存します。圧縮された JS ファイルや RTL CSS ファイルのパッチは作成しないでください。これらはソースファイルから自動的に生成されます。詳細については、[このビルドプロセス](https://make.wordpress.org/core/2013/08/06/a-new-frontier-for-core-development/)を参照してください。
+
+<!--
 Next you will create the patch file, which records the differences between your version of the files and those from WordPress trunk. Patches should be created from the root directory of your WordPress SVN install.
+-->
 
+次に、パッチファイルを作成します。このパッチファイルは、WordPress trunk のファイルとの差分を記録します。パッチは WordPress SVN インストールのルートディレクトリから作成します。
+
+<!--
 To do so, ensure that you are in the root directory created by your SVN checkout (**wordpress-svn**), then run the following command, where `00000` is replaced with the ticket number from Trac:
+-->
+
+パッチを作成するには、SVN チェックアウトで作成したルートディレクトリ (**wordpress-svn**) にいることを確認し、次のコマンドを実行します。ここで、`00000` は Trac からのチケット番号に置き換えられます:
 
 ```bash
 svn diff > 00000.diff
 ```
 
+<!--
 If you also like to automatically submit the created patch to an existing ticket, there is an easy-to-use [Grunt](https://make.wordpress.org/core/handbook/tutorials/working-with-patches/#creating-and-applying-patches-with-grunt) command available that can take care of both creating the patch and uploading it. In order to use the command, you need to have [Node.js](https://nodejs.org/) and Grunt-CLI globally installed, and you need to ensure that the WordPress development dependencies are installed locally, which you can do by running `npm install`.
+-->
 
+作成したパッチを既存のチケットに自動的に提出したい場合は、パッチの作成とアップロードの両方を行うことができる使いやすい [Grunt](https://make.wordpress.org/core/handbook/tutorials/working-with-patches/#creating-and-applying-patches-with-grunt) コマンドがあります。このコマンドを使うには、[Node.js](https://nodejs.org/) と Grunt-CLI がグローバルにインストールされている必要があります。また、WordPress の開発依存パッケージがローカルにインストールされている必要があります。これは、`npm install` を実行することでインストールできます。
+
+<!--
 The actual command to create and upload a patch works as follows:
+-->
+
+パッチを作成してアップロードする実際のコマンドは次のように機能します:
 
 ```bash
 grunt upload_patch:00000
 ```
 
+<!--
 Make sure to replace `00000` with the ticket number from Trac. During execution of the command, you may be asked for your wordpress.org user name and password.
+-->
 
+`00000` は Trac のチケット番号に置き換えてください。コマンドの実行中に、wordpress.org のユーザー名とパスワードの入力を求められる場合があります。
+
+<!--
 ### Applying a Patch with the Command Line
+-->
 
+### コマンドラインでパッチを適用する
+
+<!--
 Part of the troubleshooting/testing process involves downloading and applying patches to your local WordPress trunk install from a Trac ticket that you are involved in.
+-->
 
+トラブルシューティングやテストプロセスの一環として、あなたが関わっている Trac チケットからパッチをダウンロードして、ローカルの WordPress trunk インストールに適用することが含まれます。
+
+<!--
 To download a patch, click on the handy download icon next to the patch’s name in trac:
+-->
 
+パッチをダウンロードするには、Trac のパッチ名の横にある便利なダウンロードアイコンをクリックしてください:
+
+<!--
 [![Download a Patch from Trac Ticket Screen](https://make.wordpress.org/core/files/2013/07/smpxJogJyp-300x102.png)](https://make.wordpress.org/core/files/2013/07/smpxJogJyp.png)
+-->
 
+![Trac チケットからパッチをダウンロードする画面](https://make.wordpress.org/core/files/2013/07/smpxJogJyp.png)
+
+<!--
 On a Mac, this will save it to your default downloads folder, from where you can move it to your chosen **wordpress-svn** directory. On a Windows machine, this will prompt you to save it in your chosen location, which should be the aforementioned directory.
+-->
 
+Mac では、デフォルトのダウンロードフォルダーに保存され、そこから選択した **wordpress-svn** ディレクトリに移動できます。Windows マシンの場合は、選択した場所 (前述のディレクトリ) に保存するように求められます。
+
+<!--
 You can also download a patch via command line. Make sure that you are in the **wordpress-svn** directory, then download the patch into the **patches** folder.
+-->
+
+コマンドラインでパッチをダウンロードすることもできます。**wordpress-svn** ディレクトリにいることを確認し、**patches** フォルダーにパッチをダウンロードしてください。
 
 ```bash
 curl -O https://core.trac.wordpress.org/raw-attachment/ticket/00000/00000.diff
 ```
 
+<!--
 Note: If you download the patch this way, make sure that it is coming from the **raw-attachment** directory on the Trac server. You can get this URL by clicking on the patch in Trac, then grabbing the URL linked to by **Original Format** at the bottom of the page.
+-->
 
+注意: この方法でパッチをダウンロードする場合、Trac サーバーの **raw-attachment** ディレクトリからダウンロードされていることを確認してください。この URL は、Trac でパッチをクリックし、ページ下部の **Original Format** でリンクされている URL を取得することで取得できます。
+
+<!--
 You will need to apply the patch from the **wordpress-svn** directory, where you have downloaded the patch file. Use the following command to apply the patch:
+-->
+
+パッチファイルをダウンロードした **wordpress-svn** ディレクトリからパッチを適用する必要があります。パッチを適用するには、以下のコマンドを使用します:
 
 ```
 patch -p 0 < 00000.diff
 ```
 
+<!--
 Now, the **wordpress-svn** code has been patched with the file you downloaded, giving you the version of the code that the developer who submitted that patch was working with.
+-->
 
+これで、ダウンロードしたパッチファイルが **wordpress-svn** のコードに適用され、そのパッチを提出した開発者が作業していたバージョンのコードになります。
+
+<!--
 Note: If the patch fails to apply cleanly, you will need to leave a note on the Trac ticket that the patch needs to be refreshed, and add the **needs-refresh** keyword to the ticket.
+-->
 
+注意: もしパッチがきれいに適用できない場合は、Trac チケットにパッチの更新が必要であるというメモを残し、**needs-refresh** キーワードをチケットに追加する必要があります。
+
+<!--
 To make this process a little easier for you, there is another [Grunt](https://make.wordpress.org/core/handbook/tutorials/working-with-patches/#creating-and-applying-patches-with-grunt) command available that takes care of both downloading a patch from an existing ticket and applying it. As mentioned before, in order to use it, you need to have both [Node.js](https://nodejs.org/) and Grunt-CLI globally installed, and you also need to have the local dependencies set up, which you can do by using the command `npm install`.
+-->
 
+このプロセスを少し簡単にするために、既存のチケットからパッチをダウンロードし、それを適用するもう一つの [Grunt](https://make.wordpress.org/core/handbook/tutorials/working-with-patches/#creating-and-applying-patches-with-grunt) コマンドがあります。前述したように、このコマンドを使うには、[Node.js](https://nodejs.org/) と Grunt-CLI の両方がグローバルにインストールされている必要があります。また、ローカルでの依存関係も設定する必要がありますが、これは `npm install` を実行することでインストールできます。
+
+<!--
 You can then use the following command:
+-->
+
+その後、以下のコマンドを使用できます:
 
 ```bash
 grunt patch:00000
 ```
 
+<!--
 Make sure to replace `00000` with the ticket number from Trac. The command will automatically download the patch file from the ticket if there is only a single patch available. Otherwise, you can select which patch to download from a list, using the arrow keys on your keyboard.
+-->
 
+必ず `00000` を Trac のチケット番号に置き換えてください。利用可能なパッチが一つしかない場合、コマンドは自動的にチケットからパッチファイルをダウンロードします。そうでなければ、キーボードの矢印キーを使って、ダウンロードするパッチをリストから選択できます。
+
+<!--
 ### Reverting a Patch with the Command Line
+-->
 
+### コマンドラインでパッチを元に戻す
+
+<!--
 When you have finished testing, it is best to revert your SVN install back to the latest version of trunk, removing all applied patches and any changes you have made. You will use the following command to revert all patches/changes:
+-->
+
+テストが終了したら、インストールした SVN を最新バージョンの trunk に戻し、適用したパッチや変更点をすべて削除することをおすすめします。すべてのパッチや変更を戻すには、以下のコマンドを使います:
 
 ```bash
 svn revert -R *
 ```
 
+<!--
 ## Download a GitHub pull request
+-->
 
+## GitHub プルリクエストのダウンロード
+
+<!--
 With [hub](https://hub.github.com/) is very easy to download a pull request from a WordPress fork on a Git repo (like on GitHub). For the purpose of this section you need to install this tool on your system.
+-->
 
+[hub](https://hub.github.com/) を使用すると、(GitHub などの) Git リポジトリ上の WordPress フォークからプルリクエストをダウンロードすることがとても簡単になります。このセクションでは、このツールをシステムにインストールする必要があります。
+
+<!--
 Now you have a super version of Git that include the Hub version so inside the \``public_html` on VVV or your WP trunk folder you can execute this command (as example):
+-->
+
+これで、hub のバージョンを含むスーパーバージョンの Git が手に入ったので、VVV または WP の trunk フォルダーの `public_html` 内で次のコマンドを実行できます (例):
 
 `git checkout https://github.com/WordPress/wordpress-develop/pull/195`
 
+<!--
 This command will create automatically for you a new branch with the content of this pull request, with the ability to update that branch with the code over there.
+-->
 
+このコマンドは、そこにあるコードでそのブランチを更新する機能を備えており、このプルリクエストの内容を含む新しいブランチを自動的に作成します。
+
+<!--
 Otherwise you can download the patch or diff version of a pull request appending to the pull request url `.patch` or `.diff` like:
+-->
+
+それ以外の場合は、次のようにプルリクエストの URL に `.patch` や `.diff` を追加することで、プルリクエストのパッチ版や diff 版をダウンロードできます:
+
+git checkout https://github.com/WordPress/wordpress-develop/pull/195`
 
 *   [https://patch-diff.githubusercontent.com/raw/WordPress/wordpress-develop/pull/195.diff](https://patch-diff.githubusercontent.com/raw/WordPress/wordpress-develop/pull/195.diff)
 *   [https://patch-diff.githubusercontent.com/raw/WordPress/wordpress-develop/pull/195.patch](https://patch-diff.githubusercontent.com/raw/WordPress/wordpress-develop/pull/195.patch)
 
+<!--
 ## Next Steps
+-->
 
+## 次のステップ
+
+<!--
 *   [Submitting a Patch](https://make.wordpress.org/core/handbook/tutorials/trac/submitting-a-patch/)
+-->
+
+*   [パッチの提出](https://make.wordpress.org/core/handbook/tutorials/trac/submitting-a-patch/)


### PR DESCRIPTION
Closes #175

- 日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/4c7c4acf860a5332debec64d88554839b156c245/core/testing/automated-testing/phpunit.md
- 英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/testing/automated-testing/phpunit.md
- 英語 Web ページ: https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/

Note: WordPressコアに組み込まれているPHPのユニットテストを実行するための環境構築・方法について解説しているページです。技術的な内容なので、特に意訳した箇所はなく愚直に翻訳しています。

また、原文では一部のコンテンツにスタイルが当たっていますが、

![info](https://github.com/jawordpressorg/core-handbook/assets/54422211/a10d120a-6c44-42cc-8105-4a9bef91c575)

以下のようにショートコード＋HTMLベタ書きでやらないといけないので、そのまま再現するかどうか悩み中です。（このショートコードが https://ja.wordpress.org/team でも動く事は、一応確認済です）

![html](https://github.com/jawordpressorg/core-handbook/assets/54422211/8c50a43c-9b37-4212-bead-52984d2b1125)
