### PR TITLE
修正: QUnit ページのリスト見出しにコロンを追加

### DIFF
--- a/core/testing/automated-testing/qunit.md
+++ b/core/testing/automated-testing/qunit.md
@@ -19,14 +19,14 @@
 **1. Set up your install.** Follow one of the guides to setup your local install [https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/).
 -->
 
-**1. インストールを設定する。** このガイドに従って、ローカル環境へインストールします。
+**1. インストールを設定する:** このガイドに従って、ローカル環境へインストールします。
 [https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/)
 
 <!--
 **2. Install WordPress via SVN** Install WordPress via SVN or Git [https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-svn/](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-svn/).
 -->
 
-**2. SVN 経由で WordPress をインストールする** SVN か Git で WordPress をインストールします。
+**2. SVN 経由で WordPress をインストールする:** SVN か Git で WordPress をインストールします。
 [https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-svn/](https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-svn/)
 
 <!--


### PR DESCRIPTION
「インストールを設定する」「SVN 経由で WordPress をインストールする」のリスト見出しの部分について、次の文章との区切りが分かりづらかったのでコロンに置き換えました。

こちらのPRは新たに翻訳するものではないため、マージしたいと思います。

### Before

![before](https://github.com/jawordpressorg/core-handbook/assets/54422211/0160ca96-72a7-4bd9-9b19-6989f938ee3c)

### After

![after](https://github.com/jawordpressorg/core-handbook/assets/54422211/0d72db02-fb64-4b7e-94da-be8217377d45)