### PR TITLE
Update: references/keeping-up-with-gutenberg-index/gutenberg-index-2023.md

### DIFF
--- a/core/references/keeping-up-with-gutenberg-index/gutenberg-index-2023.md
+++ b/core/references/keeping-up-with-gutenberg-index/gutenberg-index-2023.md
@@ -1,17 +1,40 @@
+<!--
 # Gutenberg Index 2023
+-->
+
+# Gutenberg インデックス2023
 
 **Previous years: **[2020](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2020/) | [2021](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2021/)** | **[2022](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022/)****
 
+<!--
 This page is the one place you can bookmark for Gutenberg\-related team posts of Core, Core-Editor, Core-js, Core-css, Design, Meta, and Themes, and other teams, when relevant. It’s a chronological listing, not topical. Latest on top.
+-->
 
+このページは、Core、Core-Editor、Core-js、Core-css、Design、Meta、Themes の Gutenberg 関連チームの投稿を、ブックマークできるようにするためのものです。時系列順で掲載されており、トピックスではありません。最新のものから並んでいます。
+
+<!--
 *   See *[Explanations](https://make.wordpress.org/core/wp-admin/post.php?post=101683&action=edit#explanations)* on the bottom.
 *   Discussions are in the **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack channel and development happens in the [Gutenberg GitHub repository](https://github.com/WordPress/gutenberg/issues)
+-->
+
+議論は **[#core-editor](https://make.wordpress.org/core/tag/core-editor/)** Slack チャンネルで、開発は [Gutenberg GitHub リポジトリ](https://github.com/WordPress/gutenberg/issues) で行われています。
+
+下部の「[説明](#%e8%aa%ac%e6%98%8e)」をご覧ください。
+
+<!--
 *   Gutenberg [Versions in WordPress](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/) Core
 
-📙 [WordPress **6.2** Dev Notes](https://make.wordpress.org/core/tag/dev-notes+6.2/) | 📓 [WordPress 6.3 Dev Notes](https://make.wordpress.org/core/tag/dev-notes+6.3) | 📘 [WordPress 6.4 Dev Notes](https://make.wordpress.org/core/tag/dev-notes+6.-4)
+📙 [WordPress **6.2** Dev Notes](https://make.wordpress.org/core/tag/dev-notes+6.2/) | 📓 [WordPress 6.3 Dev Notes](https://make.wordpress.org/core/tag/dev-notes+6.3) | 📘 [WordPress 6.4 Dev Notes](https://make.wordpress.org/core/tag/dev-notes+6.-4) 
+-->
+
+-   [WordPress における Gutenberg のバージョン](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/)
+-   📗 [WordPress 6.2の開発者ノート](https://make.wordpress.org/core/tag/dev-notes+6.2/)
+-   📙 [WordPress 6.3の開発者ノート](https://make.wordpress.org/core/tag/dev-notes+6.3)
+-   📘 [WordPress 6.4の開発者ノート](https://make.wordpress.org/core/tag/dev-notes+6.-4)
 
 * * *
 
+<!--
 [January](#january)
 
 [February](#feb)
@@ -33,6 +56,7 @@ This page is the one place you can bookmark for Gutenberg\-related team posts of
 [October](#oct)
 
 [November](#nov)
+-->
 
 **December 2023**
 
@@ -748,12 +772,21 @@ This page is the one place you can bookmark for Gutenberg\-related team posts of
 
 2023-01-02 **[#core](https://make.wordpress.org/core/tag/core/)** The [Keeping up with Gutenberg Index 2022](https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/keeping-up-with-gutenberg-index-2022/) is now a child page of this year. (u)
 
+<!--
 **Happy New Year!** 🎆 🙌 🎉🥂 *Welcome to the 4th year of Gutenberg Index.*
+-->
+
+**ハッピーニューイヤー !** 🎆 🙌🎉🥂 Gutenberg インデックスの4年目へようこそ。
 
 * * *
 
+<!--
 **Explanations**
+-->
 
+## 説明
+
+<!--
 *   **[#team](https://make.wordpress.org/core/tag/team/)** identifies a team’s WordPress Slack channel. [Join the Slack space](https://chat.wordpress.org/).
 *   (m) = Meeting Summaries/Notes, [check here for meeting days and times](http://make.wordpresss.org/meetings)
 *   (r) = general resource
@@ -761,9 +794,30 @@ This page is the one place you can bookmark for Gutenberg\-related team posts of
 *   We use universal date format in yyyy-mm-dd to indicate publication date.
 *   Separators divide the list by weeks
 *   *This page started in January 2021. The index started in July 2020*
+-->
 
+*   **[#team](https://make.wordpress.org/core/tag/team/)** は、チームの WordPress Slack チャンネルを特定します。[Slack スペースに参加する](https://chat.wordpress.org/)。
+*   (m) = ミーティングサマリーやノート。[ミーティング日時はこちらでご確認ください](http://make.wordpresss.org/meetings)。
+*   (r) = 一般的なリソース
+*   (u) = ソフトウェア、方法、プロセス、または議論の更新を示します
+*   投稿日を示すために、yyyy-mm-dd の世界共通の日付形式を使用しています。
+*   セパレーターでリストを週ごとに分割しています。
+*   このページは2021年1月にスタートしました。インデックスは2020年7月より開始しました。
+
+<!--
 Big thanks to Anne McCarthy @annezazu and William Patton @williampatton for support and review.
+-->
 
+Anne McCarthy @annezazu と William Patton @williampatton のサポートとレビューに感謝します。
+
+<!--
 If you find a post missing or you would like to help with this effort, ping Birgit Pauli-Haack (@bph) on Slack with the link and she will add it as soon as possible.
+-->
 
+もし、投稿がないのを見つけたり、この取り組みに協力したい場合は、Slack の Birgit Pauli-Haack (@bph) に連絡していただければ、できるだけ早く追加します。
+
+<!--
 Featured Image: Photo by [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
+-->
+
+アイキャッチ画像: [Unsplash](https://unsplash.com/s/photos/block-type?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) の [Raphael Schaller](https://unsplash.com/@raphaelphotoch?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) による写真


### PR DESCRIPTION
Part of #218
Related to #111

- 日本語 GitHubページ (作業したもの): https://github.com/jawordpressorg/core-handbook/blob/4f62f5e980274351c40d5870fbe4bfca7f38fd68/core/references/keeping-up-with-gutenberg-index/gutenberg-index-2023.md
- 英語 GitHub ページ: https://github.com/jawordpressorg/core-handbook/blob/en/core/references/keeping-up-with-gutenberg-index/gutenberg-index-2023.md
- 英語 Web ページ: https://make.wordpress.org/core/handbook/references/keeping-up-with-gutenberg-index/gutenberg-index-2023/
 
Gutenberg関連の投稿をリストアップしたページで、2024年を迎えた事で作成された2023年のページです。

全ての翻訳が過去年からのコピペであるため、このままマージしたいと思います。

